### PR TITLE
Fix non-string manufacturer passed to device registry

### DIFF
--- a/custom_components/myhome/__init__.py
+++ b/custom_components/myhome/__init__.py
@@ -31,6 +31,17 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = ["light", "switch", "cover", "climate", "binary_sensor", "sensor"]
 
 
+def _coerce_str(value):
+    """Coerce legacy tuple/list values (from older manual config entries) to a plain string.
+
+    The device registry rejects non-string values; older config entries stored some
+    fields (e.g. manufacturer) wrapped in a single-element tuple.
+    """
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else None
+    return value
+
+
 async def async_setup(hass, config):
     """Set up the MyHOME component."""
     hass.data[DOMAIN] = {}
@@ -124,10 +135,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         identifiers={
             (DOMAIN, hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].unique_id)
         },
-        manufacturer=hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].manufacturer,
-        name=hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].name,
-        model=hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].model,
-        sw_version=hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].firmware,
+        manufacturer=_coerce_str(hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].manufacturer),
+        name=_coerce_str(hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].name),
+        model=_coerce_str(hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].model),
+        sw_version=_coerce_str(hass.data[DOMAIN][entry.data[CONF_MAC]][CONF_ENTITY].firmware),
     )
 
     await hass.config_entries.async_forward_entry_setups(

--- a/custom_components/myhome/config_flow.py
+++ b/custom_components/myhome/config_flow.py
@@ -148,14 +148,14 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["serialNumber"] = "invalid_mac"
 
             if not errors:
-                user_input["ssdp_location"] = (None,)
-                user_input["ssdp_st"] = (None,)
-                user_input["deviceType"] = (None,)
-                user_input["friendlyName"] = (None,)
-                user_input["manufacturer"] = ("BTicino S.p.A.",)
-                user_input["manufacturerURL"] = ("http://www.bticino.it",)
-                user_input["modelNumber"] = (None,)
-                user_input["UDN"] = (None,)
+                user_input["ssdp_location"] = None
+                user_input["ssdp_st"] = None
+                user_input["deviceType"] = None
+                user_input["friendlyName"] = None
+                user_input["manufacturer"] = "BTicino S.p.A."
+                user_input["manufacturerURL"] = "http://www.bticino.it"
+                user_input["modelNumber"] = None
+                user_input["UDN"] = None
                 self.gateway_handler = OWNGateway(user_input)
                 await self.async_set_unique_id(user_input["serialNumber"], raise_on_progress=False)
                 return await self.async_step_test_connection()


### PR DESCRIPTION
The manual config flow wrapped gateway metadata values in single-element tuples (a stray trailing comma), so `manufacturer` was stored as a tuple instead of a string. Home Assistant's device registry rejects non-string values and warns this will stop working in 2026.12.0.

- config_flow.py: store the manual-entry values as plain strings/None.
- __init__.py: defensively coerce list/tuple values to a string when building the gateway device entry, so existing config entries that already stored the tuple no longer trigger the warning.