### PR TITLE
Fix setup failure on HA Core 2026.9+ (nested schema post-processing skipped)

### DIFF
--- a/custom_components/myhome/validate.py
+++ b/custom_components/myhome/validate.py
@@ -421,15 +421,21 @@ climate_schema = MyHomeDeviceSchema(
     }
 )
 
+# The device schemas are Schema subclasses whose overridden __call__ performs
+# post-processing (rekeying to "who-where" and injecting default keys). Nested
+# schema instances are not guaranteed to be invoked through __call__ by the
+# validation engine (HA Core 2026.9 replaced voluptuous with probatio, whose
+# compatibility shim compiles nested Schema declarations directly), so wrap
+# them in plain callables to force the subclass __call__ to run.
 gateway_schema = Schema(
     {
         Required(CONF_MAC): MacAddress(),
-        Optional(LIGHT): light_schema,
-        Optional(SWITCH): switch_schema,
-        Optional(COVER): cover_schema,
-        Optional(BINARY_SENSOR): binary_sensor_schema,
-        Optional(SENSOR): sensor_schema,
-        Optional(CLIMATE): climate_schema,
+        Optional(LIGHT): lambda v: light_schema(v),
+        Optional(SWITCH): lambda v: switch_schema(v),
+        Optional(COVER): lambda v: cover_schema(v),
+        Optional(BINARY_SENSOR): lambda v: binary_sensor_schema(v),
+        Optional(SENSOR): lambda v: sensor_schema(v),
+        Optional(CLIMATE): lambda v: climate_schema(v),
     }
 )
 


### PR DESCRIPTION
## Problem

Since HA Core 2026.9.0, the integration fails to set up: the config entry lands in `setup_error`, all entities become `unavailable`, and retries log `ValueError: Config entry ... has already been setup!`.

Fixes #222 — full analysis in [this comment](https://github.com/anotherjulien/MyHOME/issues/222#issuecomment-5518774606).

## Root cause

HA Core 2026.9.0 replaced `voluptuous` with [probatio](https://github.com/frenck/probatio) (`probatio==0.11.4`), whose compatibility shim serves the `voluptuous` import. The shim compiles nested `Schema` instances from their declaration without invoking an overridden `__call__`.

`validate.py` relies on `Schema` subclasses (`MyHomeDeviceSchema`, `MyHomeSensorSchema`) whose `__call__` post-processes validated data: rekeying devices to `who-where` keys and injecting the `entities`/`icon`/`icon_on`/`entity_name`/`model` defaults. With that post-processing skipped for the schemas nested inside `gateway_schema`, platform setup crashes:

- `KeyError: 'icon'` (light.py L56)
- `KeyError: 'entity_name'` (cover.py L52)
- `KeyError: 'model'` (button.py L57)
- `KeyError: 'entities'` (__init__.py L164)

The top-level `config_schema` still works because `__init__.py` calls it directly, which is why setup gets far enough to half-register the platforms — hence the misleading `has already been setup!` errors on every retry.

## Fix

Wrap the nested device schemas in plain callables so the subclass `__call__` always runs, whichever engine compiles the schema. Behavior on older HA versions (real voluptuous) is unchanged: it treated nested `Schema` instances as callables anyway.

## Tested

HA Core 2026.9.0 (HAOS), MyHOME 0.9.3, F454 gateway, config with 6 lights + 1 cover: entry loads, all entities (including the derived buttons) are back and functional after a core restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)