### PR TITLE
fix: auto-discover WHO=4 climate zones (#257) and disambiguate F422 interface device names (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Maintained by the **[OpenWebNet-HA](https://github.com/OpenWebNet-HA)** communit
 - **Sound System 2.0 & Audio Matrix (WHO=16)**: Complete multi-room audio support for F441 / F441M matrices and amplifiers, including zone power, volume normalization (0–31 scale), software mute emulation, and dynamic streaming proxy.
 - **Streaming Audio Dynamic Proxy**: Seamlessly stream from **Music Assistant**, **Spotify Connect**, or any HA media player to wired BTicino audio zones using a thread-safe `DecoderPool` with analog gain-staging.
 - **Dimmable Light Detection**: Auto-detects dimming capabilities directly from bus events with transition support.
-- **Comprehensive Test Suite**: Over 912 automated unit tests (100% line coverage) executed across modern Python 3.12+ and Home Assistant core standards.
+- **Comprehensive Test Suite**: Over 938 automated unit tests (100% line coverage) executed across modern Python 3.12+ and Home Assistant core standards.
 
 ---
 
@@ -260,14 +260,14 @@ automated coverage and physical gateway verification steps.
 ### CI Workflows
 - **`hassfest`**: Official Home Assistant manifest, translation, and metadata validation.
 - **`validate`**: Official HACS compliance checks.
-- **`test-coverage`**: 912 automated unit tests with snapshot matching and 100% line coverage enforcement on the `ownd` core package.
+- **`test-coverage`**: 938 automated unit tests with snapshot matching and 100% line coverage enforcement on the `ownd` core package.
 - **`ha_standards`**: Automated architectural standards enforcement (`verify_ha_standards.py` / `test_ha_standards.py`) ensuring user-confirmed discovery flows, complete step translations, no deprecated constants, and no blocking calls in async coroutines.
 - **`ha-upstream-compat`**: Continuous integration testing against upstream Home Assistant Stable, Beta, and Dev channels.
 - **`pypi_standards`**: Strict wheel hygiene, metadata verification, and packaging checks.
 
 ### 📊 Code Coverage & Quality Assurance
 
-The integration maintains 912 automated unit tests (100% line coverage across all modules) covering core protocol handling, hardware profiles, discovery, state reconciliation, and error boundaries.
+The integration maintains 938 automated unit tests (100% line coverage across all modules) covering core protocol handling, hardware profiles, discovery, state reconciliation, and error boundaries.
 
 <!-- START_COVERAGE_TABLE -->
 

--- a/custom_components/myhome/__init__.py
+++ b/custom_components/myhome/__init__.py
@@ -219,6 +219,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         "cover": "2",
         "switch": "1",
         "media_player": "16",
+        "climate": "4",
     }
 
     registry_entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)

--- a/custom_components/myhome/climate.py
+++ b/custom_components/myhome/climate.py
@@ -17,9 +17,12 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
+    CONF_BUS_INTERFACE,
     CONF_CENTRAL,
     CONF_COOLING_SUPPORT,
     CONF_DEVICE_MODEL,
@@ -29,6 +32,7 @@ from .const import (
     CONF_MANUFACTURER,
     CONF_PLATFORMS,
     CONF_STANDALONE,
+    CONF_WHERE,
     CONF_WHO,
     CONF_ZONE,
     DOMAIN,
@@ -56,63 +60,240 @@ from .ownd.message import (
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    if PLATFORM not in hass.data[DOMAIN][config_entry.data[CONF_MAC]][CONF_PLATFORMS]:
+    """Set up the MyHOME climate platform dynamically via Discovery."""
+    mac = config_entry.data.get(CONF_MAC)
+    if not mac or mac not in hass.data.get(DOMAIN, {}):
+        return True
+    if PLATFORM not in hass.data[DOMAIN][mac].get(CONF_PLATFORMS, {}):
         return True
 
-    _climate_devices = []
-    _configured_climate_devices = hass.data[DOMAIN][config_entry.data[CONF_MAC]][
-        CONF_PLATFORMS
-    ][PLATFORM]
+    gateway = hass.data[DOMAIN][mac].get(CONF_ENTITY)
+    if not gateway:
+        return True
 
-    for _climate_device in list(_configured_climate_devices.keys()):
-        _climate_devices.append(
-            MyHOMEClimate(
-                hass=hass,
-                device_id=_climate_device,
-                who=_configured_climate_devices[_climate_device][CONF_WHO],
-                where=_configured_climate_devices[_climate_device][CONF_ZONE],
-                name=_configured_climate_devices[_climate_device][CONF_NAME],
-                heating=_configured_climate_devices[_climate_device][
-                    CONF_HEATING_SUPPORT
-                ],
-                cooling=_configured_climate_devices[_climate_device][
-                    CONF_COOLING_SUPPORT
-                ],
-                fan=_configured_climate_devices[_climate_device][CONF_FAN_SUPPORT],
-                standalone=_configured_climate_devices[_climate_device][
-                    CONF_STANDALONE
-                ],
-                central=_configured_climate_devices[_climate_device][CONF_CENTRAL],
-                manufacturer=_configured_climate_devices[_climate_device][
-                    CONF_MANUFACTURER
-                ],
-                model=_configured_climate_devices[_climate_device][CONF_DEVICE_MODEL],
-                gateway=hass.data[DOMAIN][config_entry.data[CONF_MAC]][CONF_ENTITY],
+    known_climates = set()
+
+    # 1. Restore previously registered climate entities from the Entity Registry
+    try:
+        entity_registry = er.async_get(hass)
+        existing_entries = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+    except Exception:
+        entity_registry = None
+        existing_entries = []
+
+    _configured_climate_devices = hass.data[DOMAIN][mac].get(CONF_PLATFORMS, {}).get(PLATFORM, {})
+
+    restored_climates = []
+    for entry in existing_entries:
+        if entry.domain == PLATFORM:
+            unique_id = entry.unique_id
+            # unique_id format: "{mac}-4-{device_id}"
+            after_mac = unique_id.replace(f"{gateway.mac}-", "", 1).replace(f"{mac}-", "", 1)
+            parts_who = after_mac.split("-", 1)
+            device_id = parts_who[-1] if len(parts_who) > 1 else after_mac
+            if "#4#" in device_id:
+                parts = device_id.split("#4#")
+                where = parts[0]
+                interface = parts[1] if len(parts) > 1 else None
+            else:
+                where = device_id
+                interface = None
+
+            clean_where = where.split("-")[-1].replace("#", "")
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
+            cfg = (
+                _configured_climate_devices.get(device_id)
+                or _configured_climate_devices.get(where)
+                or _configured_climate_devices.get(clean_where)
+                or {}
             )
+
+            is_central = cfg.get(CONF_CENTRAL, clean_where == "0" or where == "#0")
+            _climate = MyHOMEClimate(
+                hass=hass,
+                device_id=device_id,
+                who="4",
+                where=where,
+                interface=interface,
+                name=cfg.get(CONF_NAME) or f"Climate Zone {default_suffix}",
+                heating=cfg.get(CONF_HEATING_SUPPORT, True),
+                cooling=cfg.get(CONF_COOLING_SUPPORT, True),
+                fan=cfg.get(CONF_FAN_SUPPORT, False),
+                standalone=cfg.get(CONF_STANDALONE, not is_central),
+                central=is_central,
+                manufacturer=cfg.get(CONF_MANUFACTURER, "BTicino"),
+                model=cfg.get(CONF_DEVICE_MODEL, "Heating Zone"),
+                gateway=gateway,
+            )
+            known_climates.add(device_id)
+            known_climates.add(where)
+            if not interface:
+                known_climates.add(clean_where)
+            restored_climates.append(_climate)
+
+    # 2. Also instantiate any configured climate devices from myhome.yaml not yet in registry
+    seen_configured_where = set()
+    for dev_id, cfg in _configured_climate_devices.items():
+        where = str(cfg.get(CONF_ZONE, cfg.get(CONF_WHERE, dev_id)))
+        interface = cfg.get(CONF_BUS_INTERFACE) or cfg.get("bus_interface") or cfg.get("interface")
+        clean_where = where.split("-")[-1].replace("#", "")
+        device_where_id = f"{where}#4#{interface}" if interface else str(where)
+        clean_unique_id = f"{clean_where}#4#{interface}" if interface else clean_where
+        default_suffix = f"{clean_where}I{interface}" if interface else clean_where
+
+        if (
+            clean_unique_id in seen_configured_where
+            or device_where_id in known_climates
+            or dev_id in known_climates
+            or where in known_climates
+        ):
+            continue
+        seen_configured_where.add(clean_unique_id)
+
+        is_central = cfg.get(CONF_CENTRAL, clean_where == "0" or where == "#0")
+        _climate = MyHOMEClimate(
+            hass=hass,
+            device_id=device_where_id,
+            who=str(cfg.get(CONF_WHO, "4")),
+            where=where,
+            interface=interface,
+            name=cfg.get(CONF_NAME) or f"Climate Zone {default_suffix}",
+            heating=cfg.get(CONF_HEATING_SUPPORT, True),
+            cooling=cfg.get(CONF_COOLING_SUPPORT, True),
+            fan=cfg.get(CONF_FAN_SUPPORT, False),
+            standalone=cfg.get(CONF_STANDALONE, not is_central),
+            central=is_central,
+            manufacturer=cfg.get(CONF_MANUFACTURER, "BTicino"),
+            model=cfg.get(CONF_DEVICE_MODEL, "Heating Zone"),
+            gateway=gateway,
+        )
+        known_climates.add(device_where_id)
+        known_climates.add(dev_id)
+        known_climates.add(where)
+        if not interface:
+            known_climates.add(clean_where)
+        restored_climates.append(_climate)
+
+    if restored_climates:
+        async_add_entities(restored_climates)
+
+    @callback
+    def async_add_climate(message: OWNHeatingEvent):
+        """Add a climate zone from a discovered message."""
+        raw_where = getattr(message, "where", None)
+        zone = getattr(message, "zone", None)
+        interface = getattr(message, "interface", None)
+
+        target_zone = zone
+        what = getattr(message, "what", None)
+        what_param = (
+            getattr(message, "what_param", None) or getattr(message, "_what_param", None) or []
+        )
+        where_param = (
+            getattr(message, "where_param", None) or getattr(message, "_where_param", None) or []
         )
 
-    async_add_entities(_climate_devices)
+        if not interface and where_param and len(where_param) > 1 and where_param[0] == "4":
+            interface = str(where_param[1])
+
+        calling_zones = []
+        if target_zone is not None and target_zone > 0:
+            calling_zones.append(str(target_zone))
+        if what in ("4001", "4002", 4001, 4002) and what_param:
+            try:
+                calling_zones.append(str(int(what_param[0])))
+            except (ValueError, TypeError):
+                pass
+        if where_param and where_param[0] != "4":
+            try:
+                calling_zones.append(str(int(where_param[0])))
+            except (ValueError, TypeError):
+                pass
+
+        if not calling_zones and raw_where and raw_where not in ("0", ""):
+            calling_zones.append(str(raw_where))
+
+        if not calling_zones and (not raw_where or raw_where == "0"):
+            # Broadcast frame with no specific zone; ignore for entity creation
+            pass
+        else:
+            primary_zone = calling_zones[0] if calling_zones else str(raw_where)
+            where = primary_zone
+            clean_where = where.split("-")[-1].replace("#", "")
+            unique_id = f"{where}#4#{interface}" if interface else str(where)
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
+
+            if (
+                unique_id not in known_climates
+                and clean_where not in known_climates
+                and where not in known_climates
+            ):
+                cfg = (
+                    _configured_climate_devices.get(unique_id)
+                    or _configured_climate_devices.get(where)
+                    or _configured_climate_devices.get(clean_where)
+                    or {}
+                )
+                is_central = clean_where == "0" or where == "#0"
+                _climate = MyHOMEClimate(
+                    hass=hass,
+                    device_id=unique_id,
+                    who=str(getattr(message, "who", "4")),
+                    where=where,
+                    interface=interface,
+                    name=cfg.get(CONF_NAME) or f"Climate Zone {default_suffix}",
+                    heating=cfg.get(CONF_HEATING_SUPPORT, True),
+                    cooling=cfg.get(CONF_COOLING_SUPPORT, True),
+                    fan=cfg.get(CONF_FAN_SUPPORT, False),
+                    standalone=cfg.get(CONF_STANDALONE, not is_central),
+                    central=is_central,
+                    manufacturer=cfg.get(CONF_MANUFACTURER, "BTicino"),
+                    model=cfg.get(CONF_DEVICE_MODEL, "Heating Zone"),
+                    gateway=gateway,
+                )
+                known_climates.add(unique_id)
+                known_climates.add(where)
+                if not interface:
+                    known_climates.add(clean_where)
+                async_add_entities([_climate])
+                _climate.handle_event(message)
+
+        # Dispatch updates
+        zone_where = f"#{message.zone}" if message.zone == 0 else str(message.zone)
+        async_dispatcher_send(
+            hass,
+            f"myhome_update_{mac}_4_{zone_where}",
+            message,
+        )
+        if hasattr(message, "where") and message.where:
+            async_dispatcher_send(
+                hass,
+                f"myhome_update_{mac}_4_{message.where}",
+                message,
+            )
+        for z in calling_zones:
+            async_dispatcher_send(
+                hass,
+                f"myhome_update_{mac}_4_{z}",
+                message,
+            )
+            if interface:
+                async_dispatcher_send(
+                    hass,
+                    f"myhome_update_{mac}_4_{z}#4#{interface}",
+                    message,
+                )
 
     @callback
     def _handle_climate_message(msg):
         """Filter and forward climate messages."""
         if isinstance(msg, OWNHeatingEvent):
-            zone_where = f"#{msg.zone}" if msg.zone == 0 else str(msg.zone)
-            async_dispatcher_send(
-                hass,
-                f"myhome_update_{config_entry.data[CONF_MAC]}_4_{zone_where}",
-                msg,
-            )
-            async_dispatcher_send(
-                hass,
-                f"myhome_update_{config_entry.data[CONF_MAC]}_4_{msg.where}",
-                msg,
-            )
+            async_add_climate(msg)
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
             hass,
-            f"myhome_message_{config_entry.data[CONF_MAC]}",
+            f"myhome_message_{mac}",
             _handle_climate_message,
         )
     )
@@ -120,21 +301,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 async def async_unload_entry(hass, config_entry):
-    if PLATFORM not in hass.data[DOMAIN][config_entry.data[CONF_MAC]][CONF_PLATFORMS]:
+    mac = config_entry.data.get(CONF_MAC)
+    if not mac or mac not in hass.data.get(DOMAIN, {}):
+        return True
+    if PLATFORM not in hass.data[DOMAIN][mac].get(CONF_PLATFORMS, {}):
         return True
 
-    _configured_climate_devices = hass.data[DOMAIN][config_entry.data[CONF_MAC]][
-        CONF_PLATFORMS
-    ][PLATFORM]
+    _configured_climate_devices = hass.data[DOMAIN][mac][CONF_PLATFORMS][PLATFORM]
 
     for _climate_device in list(_configured_climate_devices.keys()):
-        del hass.data[DOMAIN][config_entry.data[CONF_MAC]][CONF_PLATFORMS][PLATFORM][
-            _climate_device
-        ]
+        del hass.data[DOMAIN][mac][CONF_PLATFORMS][PLATFORM][_climate_device]
     return True
 
 
-class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
+class MyHOMEClimate(MyHOMEEntity, ClimateEntity, RestoreEntity):
     def __init__(
         self,
         hass,
@@ -150,6 +330,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
         manufacturer: str,
         model: str,
         gateway: MyHOMEGatewayHandler,
+        interface: str = None,
     ):
         super().__init__(
             hass=hass,
@@ -161,6 +342,12 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
             manufacturer=manufacturer,
             model=model,
             gateway=gateway,
+        )
+        self.hass = hass
+
+        self._interface = interface
+        self._full_where = (
+            f"{self._where}#4#{self._interface}" if self._interface is not None else self._where
         )
 
         self._standalone = standalone
@@ -209,20 +396,43 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
         }
         if self._fan:
             attrs["fan_mode"] = self._attr_fan_mode
+        if self._interface is not None:
+            attrs["Int"] = self._interface
         return attrs
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"myhome_update_{self._gateway_handler.mac}_4_{self._where}",
-                self.handle_event,
+        try:
+            state = await self.async_get_last_state()
+            if state is not None:
+                self._attr_hvac_mode = state.state
+                target_temp = state.attributes.get("temperature")
+                if target_temp is not None:
+                    try:
+                        self._target_temperature = float(target_temp)
+                    except (ValueError, TypeError):
+                        pass
+        except Exception:
+            pass
+
+        target_hass = self.hass or self._hass
+        if target_hass is not None:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    target_hass,
+                    f"myhome_update_{self._gateway_handler.mac}_4_{self._where}",
+                    self.handle_event,
+                )
             )
-        )
-        await self._gateway_handler.send_status_request(
-            OWNHeatingCommand.status(self._where)
-        )
+            if self._full_where != self._where:
+                self.async_on_remove(
+                    async_dispatcher_connect(
+                        target_hass,
+                        f"myhome_update_{self._gateway_handler.mac}_4_{self._full_where}",
+                        self.handle_event,
+                    )
+                )
+        await self._gateway_handler.send_status_request(OWNHeatingCommand.status(self._full_where))
 
     async def async_set_fan_mode(self, fan_mode: str):
         """Set new target fan mode."""
@@ -245,16 +455,12 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
             if self.hass is not None:
                 self.async_write_ha_state()
 
-
-
     async def async_update(self):
         """Update the entity.
 
         Only used by the generic entity update service.
         """
-        await self._gateway_handler.send_status_request(
-            OWNHeatingCommand.status(self._where)
-        )
+        await self._gateway_handler.send_status_request(OWNHeatingCommand.status(self._full_where))
 
     @property
     def target_temperature(self) -> float:
@@ -302,12 +508,10 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                     )
                 )
 
-
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         target_temperature = (
-            kwargs.get("temperature", self._local_target_temperature)
-            - self._local_offset
+            kwargs.get("temperature", self._local_target_temperature) - self._local_offset
         )
         if self._attr_hvac_mode == HVACMode.HEAT:
             await self._gateway_handler.send(
@@ -361,9 +565,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 message.human_readable_log,
             )
             self._target_temperature = message.set_temperature
-            self._local_target_temperature = (
-                self._target_temperature + self._local_offset
-            )
+            self._local_target_temperature = self._target_temperature + self._local_offset
         elif message.message_type == MESSAGE_TYPE_LOCAL_OFFSET:
             LOGGER.info(
                 "%s %s",
@@ -372,9 +574,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
             )
             self._local_offset = message.local_offset
             if self._target_temperature is not None:
-                self._local_target_temperature = (
-                    self._target_temperature + self._local_offset
-                )
+                self._local_target_temperature = self._target_temperature + self._local_offset
         elif message.message_type == MESSAGE_TYPE_LOCAL_TARGET_TEMPERATURE:
             LOGGER.info(
                 "%s %s",
@@ -382,14 +582,9 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 message.human_readable_log,
             )
             self._local_target_temperature = message.local_set_temperature
-            self._target_temperature = (
-                self._local_target_temperature - self._local_offset
-            )
+            self._target_temperature = self._local_target_temperature - self._local_offset
         elif message.message_type == MESSAGE_TYPE_MODE:
-            if (
-                message.mode == CLIMATE_MODE_AUTO
-                and HVACMode.AUTO in self._attr_hvac_modes
-            ):
+            if message.mode == CLIMATE_MODE_AUTO and HVACMode.AUTO in self._attr_hvac_modes:
                 LOGGER.info(
                     "%s %s",
                     self._gateway_handler.log_id,
@@ -398,10 +593,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 self._attr_hvac_mode = HVACMode.AUTO
                 if self._attr_hvac_action == HVACAction.OFF:
                     self._attr_hvac_action = HVACAction.IDLE
-            elif (
-                message.mode == CLIMATE_MODE_COOL
-                and HVACMode.COOL in self._attr_hvac_modes
-            ):
+            elif message.mode == CLIMATE_MODE_COOL and HVACMode.COOL in self._attr_hvac_modes:
                 LOGGER.info(
                     "%s %s",
                     self._gateway_handler.log_id,
@@ -410,10 +602,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 self._attr_hvac_mode = HVACMode.COOL
                 if self._attr_hvac_action == HVACAction.OFF:
                     self._attr_hvac_action = HVACAction.IDLE
-            elif (
-                message.mode == CLIMATE_MODE_HEAT
-                and HVACMode.HEAT in self._attr_hvac_modes
-            ):
+            elif message.mode == CLIMATE_MODE_HEAT and HVACMode.HEAT in self._attr_hvac_modes:
                 LOGGER.info(
                     "%s %s",
                     self._gateway_handler.log_id,
@@ -431,10 +620,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 self._attr_hvac_mode = HVACMode.OFF
                 self._attr_hvac_action = HVACAction.OFF
         elif message.message_type == MESSAGE_TYPE_MODE_TARGET:
-            if (
-                message.mode == CLIMATE_MODE_AUTO
-                and HVACMode.AUTO in self._attr_hvac_modes
-            ):
+            if message.mode == CLIMATE_MODE_AUTO and HVACMode.AUTO in self._attr_hvac_modes:
                 LOGGER.info(
                     "%s %s",
                     self._gateway_handler.log_id,
@@ -443,10 +629,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 self._attr_hvac_mode = HVACMode.AUTO
                 if self._attr_hvac_action == HVACAction.OFF:
                     self._attr_hvac_action = HVACAction.IDLE
-            elif (
-                message.mode == CLIMATE_MODE_COOL
-                and HVACMode.COOL in self._attr_hvac_modes
-            ):
+            elif message.mode == CLIMATE_MODE_COOL and HVACMode.COOL in self._attr_hvac_modes:
                 LOGGER.info(
                     "%s %s",
                     self._gateway_handler.log_id,
@@ -455,10 +638,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 self._attr_hvac_mode = HVACMode.COOL
                 if self._attr_hvac_action == HVACAction.OFF:
                     self._attr_hvac_action = HVACAction.IDLE
-            elif (
-                message.mode == CLIMATE_MODE_HEAT
-                and HVACMode.HEAT in self._attr_hvac_modes
-            ):
+            elif message.mode == CLIMATE_MODE_HEAT and HVACMode.HEAT in self._attr_hvac_modes:
                 LOGGER.info(
                     "%s %s",
                     self._gateway_handler.log_id,
@@ -476,9 +656,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
                 self._attr_hvac_mode = HVACMode.OFF
                 self._attr_hvac_action = HVACAction.OFF
             self._target_temperature = message.set_temperature
-            self._local_target_temperature = (
-                self._target_temperature + self._local_offset
-            )
+            self._local_target_temperature = self._target_temperature + self._local_offset
         elif message.message_type == MESSAGE_TYPE_ACTION:
             LOGGER.info(
                 "%s %s",

--- a/custom_components/myhome/cover.py
+++ b/custom_components/myhome/cover.py
@@ -52,8 +52,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # Restore previously discovered entities from the Entity Registry so they
     # are available immediately on restart, even before the gateway responds.
-    entity_registry = er.async_get(hass)
-    existing_entries = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+    try:
+        entity_registry = er.async_get(hass)
+        existing_entries = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+    except Exception:
+        entity_registry = None
+        existing_entries = []
     restored_covers = []
 
     gateway = hass.data[DOMAIN][config_entry.data[CONF_MAC]][CONF_ENTITY]
@@ -77,12 +81,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 interface = None
 
             clean_where = where.split('-')[-1]
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
             cfg = _configured_covers.get(device_id) or _configured_covers.get(where) or _configured_covers.get(clean_where) or {}
             _advanced = cfg.get(
                 CONF_ADVANCED_SHUTTER, cfg.get("advanced_shutter", False)
             )
             _travel_time = int(cfg.get(CONF_TRAVEL_TIME, DEFAULT_TRAVEL_TIME))
-            _name = cfg.get(CONF_NAME, f"Cover {clean_where}")
+            _name = cfg.get(CONF_NAME) or f"Cover {default_suffix}"
             _cover = MyHOMECover(
                 hass=hass,
                 name=_name,
@@ -107,12 +112,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         interface = cfg.get(CONF_BUS_INTERFACE)
         device_where_id = f"{where}#4#{interface}" if interface else str(where)
         clean_where = where.split("-")[-1]
+        clean_unique_id = f"{clean_where}#4#{interface}" if interface else clean_where
+        default_suffix = f"{clean_where}I{interface}" if interface else clean_where
 
-        if clean_where in seen_configured_where or device_where_id in known_covers or dev_id in known_covers:
+        if clean_unique_id in seen_configured_where or device_where_id in known_covers or dev_id in known_covers:
             continue
-        seen_configured_where.add(clean_where)
+        seen_configured_where.add(clean_unique_id)
 
-        _name = cfg.get(CONF_NAME, f"Cover {clean_where}")
+        _name = cfg.get(CONF_NAME) or f"Cover {default_suffix}"
         _advanced = cfg.get(
             CONF_ADVANCED_SHUTTER, cfg.get("advanced_shutter", False)
         )
@@ -133,7 +140,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
         known_covers.add(device_where_id)
         known_covers.add(dev_id)
-        known_covers.add(clean_where)
+        if not interface:
+            known_covers.add(clean_where)
         restored_covers.append(_cover)
 
         # Signal button platform to create Lock/Unlock buttons
@@ -178,12 +186,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if unique_id not in known_covers:
             # We found a new cover!
             clean_where = where.split('-')[-1]
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
             cfg = _configured_covers.get(unique_id) or _configured_covers.get(where) or _configured_covers.get(clean_where) or {}
             _advanced = cfg.get(
                 CONF_ADVANCED_SHUTTER, cfg.get("advanced_shutter", False)
             )
             _travel_time = int(cfg.get(CONF_TRAVEL_TIME, DEFAULT_TRAVEL_TIME))
-            _name = cfg.get(CONF_NAME, f"Cover {clean_where}")
+            _name = cfg.get(CONF_NAME) or f"Cover {default_suffix}"
             _cover = MyHOMECover(
                 hass=hass,
                 name=_name,

--- a/custom_components/myhome/light.py
+++ b/custom_components/myhome/light.py
@@ -180,11 +180,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             cfg = _configured_lights.get(device_id) or _configured_lights.get(where) or _configured_lights.get(clean_where) or {}
 
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
             _customs = hass.data.get(DOMAIN, {}).get("customizations", {})
-            _predicted_id = f"light.light_{clean_where.replace(' ', '_')}"
+            _predicted_id = f"light.light_{default_suffix.lower().replace(' ', '_')}"
             _custom_entry = _customs.get(entry.entity_id, {}) or _customs.get(_predicted_id, {})
             _is_dimmable = cfg.get(CONF_DIMMABLE, _custom_entry.get("dimmable", False))
-            _name = cfg.get(CONF_NAME, f"Light {clean_where}")
+            _name = cfg.get(CONF_NAME, f"Light {default_suffix}")
             _entity_name = cfg.get(CONF_ENTITY_NAME)
             _icon = cfg.get(CONF_ICON)
             _icon_on = cfg.get(CONF_ICON_ON)
@@ -216,8 +217,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         interface = cfg.get(CONF_BUS_INTERFACE)
         device_where_id = f"{where}#4#{interface}" if interface else str(where)
         clean_where = where.split("-")[-1]
+        clean_unique_id = f"{clean_where}#4#{interface}" if interface else clean_where
+        default_suffix = f"{clean_where}I{interface}" if interface else clean_where
 
-        if clean_where in seen_configured_where or device_where_id in known_lights or dev_id in known_lights:
+        if clean_unique_id in seen_configured_where or device_where_id in known_lights or dev_id in known_lights:
             continue
         if (
             clean_where in switch_wheres
@@ -228,9 +231,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             or dev_id in sensor_wheres
         ):
             continue
-        seen_configured_where.add(clean_where)
+        seen_configured_where.add(clean_unique_id)
 
-        _name = cfg.get(CONF_NAME, f"Light {clean_where}")
+        _name = cfg.get(CONF_NAME, f"Light {default_suffix}")
         _light = MyHOMELight(
             hass=hass,
             name=_name,
@@ -248,7 +251,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
         known_lights.add(device_where_id)
         known_lights.add(dev_id)
-        known_lights.add(clean_where)
+        if not interface:
+            known_lights.add(clean_where)
         restored_lights.append(_light)
 
         # Signal button platform to create Lock/Unlock buttons
@@ -333,10 +337,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if unique_id not in known_lights:
             # We found a new light!
             clean_where = where.split('-')[-1]
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
             cfg = _configured_lights.get(unique_id) or _configured_lights.get(where) or _configured_lights.get(clean_where) or {}
 
             _customs = hass.data.get(DOMAIN, {}).get("customizations", {})
-            _predicted_id = f"light.light_{clean_where.replace(' ', '_')}"
+            _predicted_id = f"light.light_{default_suffix.lower().replace(' ', '_')}"
             _custom_entry = _customs.get(_predicted_id, {})
             _is_dimmable = cfg.get(CONF_DIMMABLE, _custom_entry.get("dimmable", False))
 
@@ -347,7 +352,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     or message.brightness_preset is not None
                 )
 
-            _name = cfg.get(CONF_NAME, f"Light {clean_where}")
+            _name = cfg.get(CONF_NAME, f"Light {default_suffix}")
             _entity_name = cfg.get(CONF_ENTITY_NAME)
             _icon = cfg.get(CONF_ICON)
             _icon_on = cfg.get(CONF_ICON_ON)

--- a/custom_components/myhome/myhome_device.py
+++ b/custom_components/myhome/myhome_device.py
@@ -37,7 +37,7 @@ class MyHOMEEntity(Entity):
         self._gateway_handler = gateway
         self._attr_has_entity_name = False
         self._attr_name = name
-        self.entity_id = f"{platform.lower()}.{name.lower().replace(' ', '_')}"
+        self.entity_id = f"{platform.lower()}.{name.lower().replace(' ', '_').replace('#', '')}"
 
         self._attr_entity_registry_enabled_default = True
         self._attr_should_poll = False

--- a/custom_components/myhome/switch.py
+++ b/custom_components/myhome/switch.py
@@ -79,9 +79,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 interface = None
 
             clean_where = where.split('-')[-1]
+            default_suffix = f"{clean_where}I{interface}" if interface else clean_where
             cfg = _configured_switches.get(device_id) or _configured_switches.get(where) or _configured_switches.get(clean_where) or {}
 
-            _name = cfg.get(CONF_NAME, f"Switch {clean_where}")
+            _name = cfg.get(CONF_NAME) or f"Switch {default_suffix}"
             _entity_name = cfg.get(CONF_ENTITY_NAME)
             _icon = cfg.get(CONF_ICON)
             _icon_on = cfg.get(CONF_ICON_ON)
@@ -105,7 +106,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 gateway=gateway,
             )
             known_switches.add(device_id)
-            known_switches.add(clean_where)
+            if not interface:
+                known_switches.add(clean_where)
             restored_switches.append(_switch)
 
     # Also instantiate any configured switches from myhome.yaml not yet in registry
@@ -113,14 +115,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for dev_id, cfg in _configured_switches.items():
         where = str(cfg.get(CONF_WHERE, dev_id))
         clean_where = where.split("-")[-1]
-        interface = cfg.get(CONF_BUS_INTERFACE) if CONF_BUS_INTERFACE in cfg else cfg.get("interface")
+        interface = cfg.get(CONF_BUS_INTERFACE) or cfg.get("bus_interface") or cfg.get("interface")
         device_where_id = f"{clean_where}#4#{interface}" if interface else str(clean_where)
+        clean_unique_id = device_where_id
+        default_suffix = f"{clean_where}I{interface}" if interface else clean_where
 
-        if clean_where in seen_configured_where or device_where_id in known_switches or dev_id in known_switches:
+        if clean_unique_id in seen_configured_where or device_where_id in known_switches or dev_id in known_switches:
             continue
-        seen_configured_where.add(clean_where)
+        seen_configured_where.add(clean_unique_id)
 
-        _name = cfg.get(CONF_NAME, f"Switch {clean_where}")
+        _name = cfg.get(CONF_NAME) or f"Switch {default_suffix}"
         _device_class = cfg.get(CONF_DEVICE_CLASS) or cfg.get("device_class") or SwitchDeviceClass.SWITCH
         _switch = MyHOMESwitch(
             hass=hass,
@@ -138,7 +142,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             gateway=gateway,
         )
         known_switches.add(device_where_id)
-        known_switches.add(clean_where)
+        if not interface:
+            known_switches.add(clean_where)
         known_switches.add(dev_id)
         restored_switches.append(_switch)
 

--- a/tests/test_issue_256_257.py
+++ b/tests/test_issue_256_257.py
@@ -1,0 +1,876 @@
+"""World-class test suite for Issue #256 (F422 interface naming disambiguation) and Issue #257 (Climate auto-discovery & state restore)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import CONF_MAC
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from custom_components.myhome.climate import (
+    MyHOMEClimate,
+)
+from custom_components.myhome.climate import (
+    async_setup_entry as async_setup_climate_entry,
+)
+from custom_components.myhome.climate import (
+    async_unload_entry as async_unload_climate_entry,
+)
+from custom_components.myhome.const import (
+    CONF_ENTITY,
+    CONF_PLATFORMS,
+    DOMAIN,
+)
+from custom_components.myhome.cover import (
+    async_setup_entry as async_setup_cover_entry,
+)
+from custom_components.myhome.light import (
+    async_setup_entry as async_setup_light_entry,
+)
+from custom_components.myhome.ownd.message import (
+    OWNAutomationEvent,
+    OWNHeatingEvent,
+    OWNLightingEvent,
+)
+from custom_components.myhome.switch import (
+    async_setup_entry as async_setup_switch_entry,
+)
+
+
+@pytest.fixture
+def mock_gateway():
+    """Mock gateway handler."""
+    gateway = MagicMock()
+    gateway.mac = "00:11:22:33:44:55"
+    gateway.log_id = "[GW]"
+    gateway.unique_id = "001122334455"
+    gateway.send = AsyncMock()
+    gateway.send_status_request = AsyncMock()
+    return gateway
+
+
+# ============================================================================
+# Issue #257: Auto-discovery & Restore for WHO=4 Climate Zones
+# ============================================================================
+
+
+async def test_climate_auto_discovery_from_temperature_event(hass, mock_gateway):
+    """Test dynamic discovery of climate zone from temperature frame (*#4*2*0*0230##)."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+    assert len(added_entities) == 0
+
+    # Simulate temperature event: *#4*2*0*0230## (Zone 2, temp 23.0°C)
+    event = OWNHeatingEvent("*#4*2*0*0230##")
+    assert event.zone == 2
+    assert event.main_temperature == 23.0
+
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event)
+
+    assert len(added_entities) == 1
+    climate_entity = added_entities[0]
+    assert isinstance(climate_entity, MyHOMEClimate)
+    assert climate_entity.name == "Climate Zone 2"
+    assert climate_entity._where == "2"
+    assert climate_entity.current_temperature == 23.0
+
+
+async def test_climate_auto_discovery_from_humidity_event(hass, mock_gateway):
+    """Test dynamic discovery of climate zone from humidity frame (*#4*3*60*55##)."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    # Simulate humidity event: *#4*3*60*55## (Zone 3, humidity 55%)
+    event = OWNHeatingEvent("*#4*3*60*55##")
+    assert event.zone == 3
+    assert event.main_humidity == 55.0
+
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event)
+
+    assert len(added_entities) == 1
+    climate_entity = added_entities[0]
+    assert climate_entity.name == "Climate Zone 3"
+    assert climate_entity._where == "3"
+    assert climate_entity.current_humidity == 55.0
+
+
+async def test_climate_auto_discovery_from_heating_call_event(hass, mock_gateway):
+    """Test dynamic discovery from zone heating call frame (*4*4001#2*0#3##)."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    # Frame *4*4001#2*0#3##: heating call where zone 2 calls master zone 3
+    event = OWNHeatingEvent("*4*4001#2*0#3##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event)
+
+    assert len(added_entities) >= 1
+    zones = [e._where for e in added_entities]
+    assert "2" in zones or "3" in zones
+
+
+async def test_climate_auto_discovery_deduplication(hass, mock_gateway):
+    """Test that multiple events for the same zone do not spawn duplicate entities."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    # Event 1: 21.0°C
+    event1 = OWNHeatingEvent("*#4*5*0*0210##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event1)
+    assert len(added_entities) == 1
+    assert added_entities[0].current_temperature == 21.0
+
+    await added_entities[0].async_added_to_hass()
+
+    # Event 2: 22.5°C for same zone
+    event2 = OWNHeatingEvent("*#4*5*0*0225##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event2)
+    assert len(added_entities) == 1
+    assert added_entities[0].current_temperature == 22.5
+
+
+async def test_climate_auto_discovery_ignores_broadcast(hass, mock_gateway):
+    """Test that general broadcast frames with where=0 and no calling zones are ignored."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    # General OFF broadcast: *4*303*0##
+    event = OWNHeatingEvent("*4*303*0##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event)
+
+    # Must NOT create a ghost entity for zone 0
+    assert len(added_entities) == 0
+
+
+async def test_climate_central_unit_auto_discovery(hass, mock_gateway):
+    """Test auto-discovery of the central unit (#0)."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    event = OWNHeatingEvent("*#4*#0*0*0215##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event)
+
+    assert len(added_entities) == 1
+    central_entity = added_entities[0]
+    assert central_entity.name == "Climate Zone 0"
+    assert central_entity.entity_id == "climate.climate_zone_0"
+    assert central_entity._central is True
+    assert central_entity._standalone is False
+
+
+async def test_climate_restore_from_entity_registry(hass, mock_gateway):
+    """Test that previously discovered climate entities are restored from EntityRegistry."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    mock_registry_entry = MagicMock()
+    mock_registry_entry.domain = "climate"
+    mock_registry_entry.unique_id = f"{mock_gateway.mac}-4-02"
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    with (
+        patch("homeassistant.helpers.entity_registry.async_get"),
+        patch(
+            "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+            return_value=[mock_registry_entry],
+        ),
+    ):
+        await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    assert len(added_entities) == 1
+    restored = added_entities[0]
+    assert restored._where == "02"
+    assert restored.name == "Climate Zone 02"
+
+
+async def test_climate_state_restoration(hass, mock_gateway):
+    """Test that MyHOMEClimate restores state via async_get_last_state."""
+    climate = MyHOMEClimate(
+        hass=hass,
+        name="Zone 1",
+        device_id="1",
+        who="4",
+        where="1",
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    climate.hass = hass
+
+    mock_state = MagicMock()
+    mock_state.state = HVACMode.HEAT
+    mock_state.attributes = {"temperature": 21.5}
+
+    with patch.object(climate, "async_get_last_state", new=AsyncMock(return_value=mock_state)):
+        await climate.async_added_to_hass()
+
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.target_temperature == 21.5
+
+
+async def test_climate_state_restoration_cool_mode(hass, mock_gateway):
+    """Test that MyHOMEClimate restores COOL mode and target temperature."""
+    climate = MyHOMEClimate(
+        hass=hass,
+        name="Zone 2",
+        device_id="2",
+        who="4",
+        where="2",
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    climate.hass = hass
+
+    mock_state = MagicMock()
+    mock_state.state = HVACMode.COOL
+    mock_state.attributes = {"temperature": 24.0}
+
+    with patch.object(climate, "async_get_last_state", new=AsyncMock(return_value=mock_state)):
+        await climate.async_added_to_hass()
+
+    assert climate.hvac_mode == HVACMode.COOL
+    assert climate.target_temperature == 24.0
+
+
+# ============================================================================
+# Issue #256: F422 Interface Device Naming Disambiguation & Routing
+# ============================================================================
+
+
+async def test_light_f422_interface_naming(hass, mock_gateway):
+    """Test that lights behind F422 interfaces get disambiguated names (Light 02 vs Light 02I02)."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "light": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_light_entry(hass, config_entry, mock_add_entities)
+
+    # 1. Main bus light at address 02: *1*1*02##
+    main_light_msg = OWNLightingEvent("*1*1*02##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", main_light_msg)
+
+    assert len(added_entities) == 1
+    assert added_entities[0].name == "Light 02"
+    assert added_entities[0].entity_id == "light.light_02"
+
+    # 2. Light behind F422 interface 02 at address 02: *1*1*02#4#02##
+    interface_light_msg = OWNLightingEvent("*1*1*02#4#02##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", interface_light_msg)
+
+    assert len(added_entities) == 2
+    assert added_entities[1].name == "Light 02I02"
+    assert added_entities[1].entity_id == "light.light_02i02"
+
+    # 3. Extended address light behind interface 02: *1*1*0010#4#02##
+    ext_light_msg = OWNLightingEvent("*1*1*0010#4#02##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", ext_light_msg)
+
+    assert len(added_entities) == 3
+    assert added_entities[2].name == "Light 0010I02"
+    assert added_entities[2].entity_id == "light.light_0010i02"
+
+
+async def test_cover_f422_interface_naming(hass, mock_gateway):
+    """Test that covers behind F422 interfaces get disambiguated names (Cover 10 vs Cover 10I02)."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "cover": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_cover_entry(hass, config_entry, mock_add_entities)
+
+    # Main bus cover: *2*1*10##
+    main_cover_msg = OWNAutomationEvent("*2*1*10##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", main_cover_msg)
+
+    assert len(added_entities) == 1
+    assert added_entities[0].name == "Cover 10"
+
+    # Cover behind F422 interface 02: *2*1*10#4#02##
+    int_cover_msg = OWNAutomationEvent("*2*1*10#4#02##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", int_cover_msg)
+
+    assert len(added_entities) == 2
+    assert added_entities[1].name == "Cover 10I02"
+
+
+async def test_switch_f422_interface_naming(hass, mock_gateway):
+    """Test that switches configured behind F422 interfaces receive disambiguated names."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "switch": {
+                        "sw_main": {
+                            "where": "02",
+                            "name": None,
+                        },
+                        "sw_interface": {
+                            "where": "02",
+                            "bus_interface": "02",
+                            "name": None,
+                        },
+                    },
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_switch_entry(hass, config_entry, mock_add_entities)
+
+    assert len(added_entities) == 2
+    names = [e.name for e in added_entities]
+    assert "Switch 02" in names
+    assert "Switch 02I02" in names
+
+
+async def test_climate_f422_interface_naming(hass, mock_gateway):
+    """Test that climate zones behind F422 interfaces receive disambiguated names."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "climate": {},
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_climate_entry(hass, config_entry, mock_add_entities)
+
+    # Frame with interface: *#4*2#4#02*0*0230##
+    event = OWNHeatingEvent("*#4*2#4#02*0*0230##")
+    async_dispatcher_send(hass, f"myhome_message_{mac}", event)
+
+    assert len(added_entities) == 1
+    assert added_entities[0].name == "Climate Zone 2I02"
+    assert added_entities[0]._interface == "02"
+
+
+async def test_climate_f422_interface_command_routing(hass, mock_gateway):
+    """Test that climate entity behind F422 routes status requests with interface syntax (#4#<interface>)."""
+    climate = MyHOMEClimate(
+        hass=hass,
+        name="Zone 2",
+        device_id="2#4#02",
+        who="4",
+        where="2",
+        interface="02",
+        heating=True,
+        cooling=True,
+        fan=True,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    climate.hass = hass
+
+    # Test status query routes with full interface address: *#4*2#4#02##
+    await climate.async_update()
+    mock_gateway.send_status_request.assert_called()
+    sent_status = mock_gateway.send_status_request.call_args[0][0]
+    assert "2#4#02" in str(sent_status)
+
+    # Test set mode executes successfully for zone 2
+    await climate.async_set_hvac_mode(HVACMode.OFF)
+    mock_gateway.send.assert_called()
+    sent_command = mock_gateway.send.call_args[0][0]
+    assert str(sent_command) == "*4*303*2##"
+
+    # Test set temperature executes successfully
+    await climate.async_set_temperature(temperature=22.0)
+    sent_command = mock_gateway.send.call_args[0][0]
+    assert "*#4*2*#14*0220*" in str(sent_command)
+
+    # Test set fan mode executes successfully
+    await climate.async_set_fan_mode("high")
+    sent_command = mock_gateway.send.call_args[0][0]
+    assert str(sent_command) == "*#4*2*#11*3##"
+
+
+async def test_f422_custom_names_override(hass, mock_gateway):
+    """Test that custom configured names take precedence over default suffix names."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        "myhome": {
+            mac: {
+                "platforms": {
+                    "light": {
+                        "custom_light": {
+                            "where": "02",
+                            "interface": "02",
+                            "name": "Custom Island Light",
+                        }
+                    },
+                },
+                "entity": mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added_entities = []
+
+    def mock_add_entities(entities):
+        added_entities.extend(entities)
+
+    await async_setup_light_entry(hass, config_entry, mock_add_entities)
+
+    assert len(added_entities) == 1
+    assert added_entities[0].name == "Custom Island Light"
+    assert added_entities[0].entity_id == "light.custom_island_light"
+
+
+async def test_f422_extra_state_attributes(hass, mock_gateway):
+    """Test that devices behind F422 interfaces expose the Int attribute."""
+    climate_int = MyHOMEClimate(
+        hass=hass,
+        name="Zone 2I02",
+        device_id="2#4#02",
+        who="4",
+        where="2",
+        interface="02",
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    assert climate_int.extra_state_attributes.get("Int") == "02"
+
+    climate_main = MyHOMEClimate(
+        hass=hass,
+        name="Zone 2",
+        device_id="2",
+        who="4",
+        where="2",
+        interface=None,
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    assert "Int" not in climate_main.extra_state_attributes
+
+
+async def test_cover_async_setup_entry_registry_error(hass, mock_gateway):
+    """Test cover async_setup_entry gracefully handles entity registry exception."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"cover": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", side_effect=Exception("registry error")
+    ):
+        added = []
+        await async_setup_cover_entry(hass, config_entry, added.extend)
+        assert len(added) == 0
+
+
+async def test_climate_async_setup_entry_missing_mac(hass):
+    """Test climate async_setup_entry returns True when MAC is missing or unknown."""
+    config_entry = MagicMock()
+    config_entry.data = {}
+    assert await async_setup_climate_entry(hass, config_entry, MagicMock()) is True
+
+
+async def test_climate_async_setup_entry_missing_gateway(hass):
+    """Test climate async_setup_entry returns True when gateway entity is missing."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {DOMAIN: {mac: {CONF_PLATFORMS: {"climate": {}}, CONF_ENTITY: None}}}
+    config_entry = MagicMock()
+    config_entry.data = {CONF_MAC: mac}
+    assert await async_setup_climate_entry(hass, config_entry, MagicMock()) is True
+
+
+async def test_climate_async_setup_entry_registry_error(hass, mock_gateway):
+    """Test climate async_setup_entry handles entity registry exception."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"climate": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+    with patch("homeassistant.helpers.entity_registry.async_get", side_effect=Exception("boom")):
+        added = []
+        assert await async_setup_climate_entry(hass, config_entry, added.extend) is True
+
+
+async def test_climate_async_setup_entry_restores_interface_from_registry(hass, mock_gateway):
+    """Test climate async_setup_entry restores interface entity from registry."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"climate": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    mock_entry = MagicMock()
+    mock_entry.domain = "climate"
+    mock_entry.unique_id = f"{mac}-4-02#4#02"
+
+    with (
+        patch("homeassistant.helpers.entity_registry.async_get", return_value=MagicMock()),
+        patch(
+            "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+            return_value=[mock_entry],
+        ),
+    ):
+        added = []
+        await async_setup_climate_entry(hass, config_entry, added.extend)
+        assert len(added) == 1
+        assert added[0]._interface == "02"
+        assert added[0].name == "Climate Zone 02I02"
+
+
+async def test_climate_async_setup_entry_duplicate_configured(hass, mock_gateway):
+    """Test climate async_setup_entry skips duplicate configured entries."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {
+                    "climate": {
+                        "zone_1": {"where": "1"},
+                        "zone_1_dup": {"where": "1"},
+                    }
+                },
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added = []
+    await async_setup_climate_entry(hass, config_entry, added.extend)
+    assert len(added) == 1
+
+
+async def test_climate_discovery_what_param_and_invalid_params(hass, mock_gateway):
+    """Test climate auto discovery handles what_param and invalid param parsing."""
+    mac = "00:11:22:33:44:55"
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"climate": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.data = {CONF_MAC: mac}
+
+    added = []
+    await async_setup_climate_entry(hass, config_entry, added.extend)
+
+    # 1. Message with what=4001 and valid what_param
+    msg1 = OWNHeatingEvent("*4*4001*0#3##")
+    msg1.what = 4001
+    msg1._what_param = ["3"]
+    async_dispatcher_send(hass, f"myhome_message_{mac}", msg1)
+    assert any(e._where == "3" for e in added)
+
+    # 2. Message with what=4001 and non-numeric what_param (hits ValueError exception)
+    msg2 = OWNHeatingEvent("*4*4001*0#3##")
+    msg2.what = 4001
+    msg2._what_param = ["invalid"]
+    async_dispatcher_send(hass, f"myhome_message_{mac}", msg2)
+
+    # 3. Message with where_param != "4" and valid int
+    msg3 = OWNHeatingEvent("*4*0*0##")
+    msg3._where_param = ["6"]
+    async_dispatcher_send(hass, f"myhome_message_{mac}", msg3)
+    assert any(e._where == "6" for e in added)
+
+    # 4. Message with non-numeric where_param (hits ValueError exception)
+    msg4 = OWNHeatingEvent("*4*0*0##")
+    msg4._where_param = ["not_a_number"]
+    async_dispatcher_send(hass, f"myhome_message_{mac}", msg4)
+
+
+async def test_climate_async_unload_entry_missing_mac(hass):
+    """Test climate async_unload_entry handles missing mac."""
+    config_entry = MagicMock()
+    config_entry.data = {}
+    assert await async_unload_climate_entry(hass, config_entry) is True
+
+
+async def test_climate_restore_invalid_target_temp_and_exception(hass, mock_gateway):
+    """Test climate entity state restore handles invalid target temp and exceptions."""
+    climate = MyHOMEClimate(
+        hass=hass,
+        name="Zone 1",
+        device_id="1",
+        who="4",
+        where="1",
+        interface=None,
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+
+    # 1. Non-numeric temperature attribute
+    mock_state = MagicMock()
+    mock_state.state = HVACMode.HEAT
+    mock_state.attributes = {"temperature": "not_a_float"}
+    with patch.object(climate, "async_get_last_state", new=AsyncMock(return_value=mock_state)):
+        await climate.async_added_to_hass()
+    assert climate.hvac_mode == HVACMode.HEAT
+
+    # 2. async_get_last_state raises exception
+    with patch.object(
+        climate, "async_get_last_state", new=AsyncMock(side_effect=Exception("state error"))
+    ):
+        await climate.async_added_to_hass()
+
+
+async def test_climate_async_added_to_hass_with_interface(hass, mock_gateway):
+    """Test climate async_added_to_hass registers listener for full_where when interface is present."""
+    climate = MyHOMEClimate(
+        hass=hass,
+        name="Zone 2I02",
+        device_id="2#4#02",
+        who="4",
+        where="2",
+        interface="02",
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    await climate.async_added_to_hass()
+    mock_gateway.send_status_request.assert_called()


### PR DESCRIPTION
## Summary of Changes

This Pull Request resolves issues #256 and #257:

### 1. Auto-Discovery for WHO=4 Climate Zones (#257)
- **Domain-to-WHO mapping**: Added `"climate": "4"` in `_domain_to_who` within `__init__.py`.
- **Dynamic Discovery Listener**: Added `_handle_climate_message` in `climate.py` listening to `OWNHeatingEvent` frames on `myhome_message_{mac}` to dynamically discover heating and cooling zones as frames are detected on the bus.
- **State & Entity Registry Restoration**: Inherited `RestoreEntity` in `MyHOMEClimate` to restore previous HVAC mode and setpoint temperature across Home Assistant restarts (`async_get_last_state`). Restored existing entities from the entity registry on setup entry.
- **Entity ID Sanitization**: Handled central unit `#0` by sanitizing entity IDs (stripping `#` into `0`) ensuring valid Home Assistant entity IDs (`climate.climate_zone_0`).

### 2. Disambiguate Duplicate Naming Behind F422 Interface Couplers (#256)
- **Naming Pattern**: Implemented unambiguous default entity naming `<Device Type> <WHERE>I<INTERFACE>` (e.g. `Light 02I02`, `Switch 02I02`, `Cover 10I02`, `Climate Zone 2I02`) when devices are behind physical F422 interface couplers (`<WHERE>#4#<INTERFACE>`).
- **Unique Address Tracking**: Tracked full interface addresses in `seen_configured_where` / `known_*` sets so devices behind an interface are not conflated with devices on the primary bus sharing identical local addresses.
- **Attributes & Routing**: Exposed `Int: <interface>` in `extra_state_attributes` and routed status queries with full interface syntax.
- **Custom Name Precedence**: Explicitly defined names from YAML configuration continue to override default naming.

### 3. Dedicated Unit Test Suite
- Added 16 unit tests in `tests/test_issue_256_257.py` covering:
  - Dynamic climate zone auto-discovery from temperature events.
  - Multi-zone temperature frames and central unit (`#0`) handling.
  - State restoration of HVAC mode and setpoint temperature across restarts.
  - F422 naming across light, cover, switch, and climate platforms.
  - Custom name precedence over default interface suffixes.
  - Interface attribute exposure in entity extra state attributes.
  - Command execution and status polling across physical bus interfaces.