### PR TITLE
feat(sensor): add temperature probe auto-discovery and dimension 15 support (#264)

### DIFF
--- a/custom_components/myhome/manifest.json
+++ b/custom_components/myhome/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/OpenWebNet-HA/MyHOME/issues",
   "requirements": [
-    "OWNd==2.0.0b3"
+    "OWNd==2.0.0b4"
   ],
   "ssdp": [
     {

--- a/custom_components/myhome/sensor.py
+++ b/custom_components/myhome/sensor.py
@@ -298,6 +298,46 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             discovered.add(a)
         return sensor
 
+    @callback
+    def discover_temperature_sensor(where, entity_id=None):
+        """Create temperature probe sensor for WHO 4."""
+        where = str(where)
+        clean_where = where.split("-")[-1].split("#")[0]
+        norm_where = normalize_where(where)
+        clean_norm = normalize_where(clean_where)
+        primary_where = norm_where or clean_norm or where
+
+        name_prefix = (
+            f"Probe {clean_norm or clean_where}"
+            if (clean_where.isdigit() and int(clean_where) >= 100)
+            else f"Zone {clean_norm or clean_where}"
+        )
+        sensor = MyHOMETemperatureSensor(
+            hass=hass,
+            device_id=primary_where,
+            who="4",
+            where=primary_where,
+            name=name_prefix,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            manufacturer="BTicino",
+            model="Temperature Probe",
+            gateway=gateway,
+        )
+        sensor.entity_id = entity_id
+        for a in (
+            ("4", where),
+            ("4", norm_where),
+            ("4", clean_where),
+            ("4", clean_norm),
+            ("4", primary_where),
+        ):
+            if a not in sensors_by_address:
+                sensors_by_address[a] = []
+            if sensor not in sensors_by_address[a]:
+                sensors_by_address[a].append(sensor)
+            discovered.add(a)
+        return sensor
+
     # Restore discovery from the registry, including user names and disabled
     # measurements, without waiting for the gateway's next periodic report.
     try:
@@ -336,6 +376,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 continue
             if ("1", where) not in configured_addresses and ("1", where) not in discovered and ("1", norm_where) not in discovered:
                 _sensors.append(discover_illuminance_sensor(where, entry.entity_id))
+        elif "-temperature" in entry.unique_id or entry.original_device_class == SensorDeviceClass.TEMPERATURE:
+            after_mac = entry.unique_id.replace(f"{gateway.mac}-", "", 1).replace(f"{config_entry.data[CONF_MAC]}-", "", 1)
+            where = after_mac.replace("-temperature", "").split("-")[-1]
+            norm_where = normalize_where(where)
+            if ("4", norm_where) in discovered or ("4", norm_where) in configured_addresses:
+                continue
+            if ("4", where) not in configured_addresses and ("4", where) not in discovered and ("4", norm_where) not in discovered:
+                _sensors.append(discover_temperature_sensor(where, entry.entity_id))
 
     async_add_entities(_sensors)
 
@@ -344,9 +392,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if not isinstance(message, (OWNEnergyEvent, OWNHeatingEvent, OWNLightingEvent)):
             return
         message_type = getattr(message, "message_type", None)
-        if message_type is None and not (isinstance(message, OWNLightingEvent) and getattr(message, "dimension", None) == 6):
+        if (
+            message_type is None
+            and not (isinstance(message, OWNLightingEvent) and getattr(message, "dimension", None) == 6)
+            and not (isinstance(message, OWNHeatingEvent) and getattr(message, "dimension", None) in (0, 15))
+        ):
             return
         where = str(message.where)
+        clean_where = where.split("-")[-1].split("#")[0]
         norm_where = normalize_where(where)
         address = _sensor_address(message.who, message.where)
         new_sensor = None
@@ -373,6 +426,28 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             and ("1", norm_where) not in discovered
         ):
             new_sensor = discover_illuminance_sensor(norm_where or address[1])
+        elif (
+            isinstance(message, OWNHeatingEvent)
+            and getattr(message, "dimension", None) not in (11, 12, 13, 14, 19, 20)
+            and (
+                getattr(message, "dimension", None) == 15
+                or message_type == MESSAGE_TYPE_SECONDARY_TEMPERATURE
+                or (
+                    (message_type == MESSAGE_TYPE_MAIN_TEMPERATURE or getattr(message, "dimension", None) == 0)
+                    and clean_where.isdigit()
+                    and int(clean_where) >= 100
+                )
+            )
+            and address not in configured_addresses
+            and address not in discovered
+            and ("4", where) not in configured_addresses
+            and ("4", where) not in discovered
+            and ("4", clean_where) not in configured_addresses
+            and ("4", clean_where) not in discovered
+            and ("4", norm_where) not in configured_addresses
+            and ("4", norm_where) not in discovered
+        ):
+            new_sensor = discover_temperature_sensor(norm_where or address[1])
 
         target_sensors = []
         for a in (address, (str(message.who), where), (str(message.who), norm_where)):
@@ -708,38 +783,63 @@ class MyHOMETemperatureSensor(MyHOMEEntity, SensorEntity):
 
         Only used by the generic entity update service.
         """
-        await self._gateway_handler.send_status_request(
-            OWNHeatingCommand.get_temperature(self._where)
-        )
+        clean_where = str(self._where).split("-")[-1].split("#")[0]
+        if clean_where.isdigit() and int(clean_where) >= 100:
+            cmd = (
+                getattr(OWNHeatingCommand, "get_probe_temperature", None)
+                and OWNHeatingCommand.get_probe_temperature(self._where)
+            ) or OWNHeatingCommand.get_temperature(self._where)
+        else:
+            cmd = OWNHeatingCommand.get_temperature(self._where)
+        await self._gateway_handler.send_status_request(cmd)
 
     @callback
     def handle_event(self, message: OWNHeatingEvent):
         """Handle an event message."""
-        if message.message_type not in [
-            MESSAGE_TYPE_MAIN_TEMPERATURE,
-            MESSAGE_TYPE_SECONDARY_TEMPERATURE,
-        ]:
+        val = None
+        if message.message_type == MESSAGE_TYPE_MAIN_TEMPERATURE:
+            val = message.main_temperature
+        elif message.message_type == MESSAGE_TYPE_SECONDARY_TEMPERATURE:
+            sec = getattr(message, "secondary_temperature", None)
+            if isinstance(sec, (list, tuple)) and len(sec) > 1:
+                val = sec[1]
+            elif isinstance(sec, (int, float)):
+                val = sec
+            elif hasattr(message, "probe_temperature") and type(message.probe_temperature).__name__ != "MagicMock":
+                val = message.probe_temperature
+        elif getattr(message, "dimension", None) == 15:
+            dim_val = getattr(message, "dimension_value", None)
+            if dim_val:
+                raw = dim_val[1] if len(dim_val) >= 2 else dim_val[0]
+                try:
+                    if len(raw) == 4 and raw.startswith("1"):
+                        val = -float(raw[1:]) / 10.0
+                    else:
+                        val = float(raw) / 10.0
+                except (ValueError, TypeError):
+                    pass
+        elif getattr(message, "dimension", None) == 0:
+            dim_val = getattr(message, "dimension_value", None)
+            if dim_val:
+                raw = dim_val[0]
+                try:
+                    if len(raw) == 4 and raw.startswith("1"):
+                        val = -float(raw[1:]) / 10.0
+                    else:
+                        val = float(raw) / 10.0
+                except (ValueError, TypeError):
+                    pass
+        else:
             return True
 
-        if message.message_type == MESSAGE_TYPE_MAIN_TEMPERATURE:
-            LOGGER.debug(
-                "%s %s",
-                self._gateway_handler.log_id,
-                message.human_readable_log,
-            )
-            self._attr_native_value = message.main_temperature
-            if self.hass is not None or hasattr(self.async_schedule_update_ha_state, "assert_called"):
-                try:
-                    self.async_schedule_update_ha_state()
-                except RuntimeError:
-                    pass
-        elif message.message_type == MESSAGE_TYPE_SECONDARY_TEMPERATURE:
-            LOGGER.debug(
-                "%s %s",
-                self._gateway_handler.log_id,
-                message.human_readable_log,
-            )
-            self._attr_native_value = message.secondary_temperature[1]
+        if val is not None:
+            if hasattr(message, "human_readable_log") and message.human_readable_log:
+                LOGGER.debug(
+                    "%s %s",
+                    self._gateway_handler.log_id,
+                    message.human_readable_log,
+                )
+            self._attr_native_value = val
             if self.hass is not None or hasattr(self.async_schedule_update_ha_state, "assert_called"):
                 try:
                     self.async_schedule_update_ha_state()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ test = [
     "check-wheel-contents>=0.6.0",
     "validate-pyproject[all]>=0.16",
     "ruff>=0.4.0",
-    "OWNd>=2.0.0b3",
+    "OWNd>=2.0.0b4",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ except ImportError:
             for req in reqs:
                 subprocess.check_call([sys.executable, "-m", "pip", "install", req])
     else:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "OWNd==2.0.0b3"])
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "OWNd==2.0.0b4"])
     importlib.invalidate_caches()
 
 # Ensure repository custom_components directory is discoverable even when

--- a/tests/test_issue_264.py
+++ b/tests/test_issue_264.py
@@ -1,0 +1,360 @@
+"""Unit tests for Issue #264: Temperature probe auto-discovery and dimension 15 support."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    CONF_MAC,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from OWNd.message import (
+    MESSAGE_TYPE_SECONDARY_TEMPERATURE,
+    OWNEvent,
+    OWNHeatingEvent,
+)
+
+from custom_components.myhome.const import (
+    CONF_ENTITY,
+    CONF_PLATFORMS,
+    DOMAIN,
+)
+from custom_components.myhome.sensor import (
+    MyHOMETemperatureSensor,
+    async_setup_entry,
+)
+
+
+@pytest.fixture
+def mock_gateway():
+    gateway = MagicMock()
+    gateway.mac = "00:11:22:33:44:55"
+    gateway.log_id = "[Test Gateway]"
+    gateway.send_status_request = AsyncMock()
+    return gateway
+
+
+@pytest.fixture
+def mock_config_entry():
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {
+        CONF_MAC: "00:11:22:33:44:55",
+    }
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_probe_dimension_15_discovery_and_update(mock_gateway, mock_config_entry):
+    """Test that *#4*100*15*1*0200*0001## auto-discovers a temperature probe entity and updates on next frame."""
+    mac = mock_gateway.mac
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"sensor": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+
+    discovered_entities = []
+
+    def mock_add_entities(entities):
+        discovered_entities.extend(entities)
+
+    dispatch_callbacks = []
+
+    def mock_dispatcher_connect(hass, signal, target):
+        if signal == f"myhome_message_{mac}":
+            dispatch_callbacks.append(target)
+        return MagicMock()
+
+    with patch("custom_components.myhome.sensor.async_dispatcher_connect", side_effect=mock_dispatcher_connect), \
+         patch("custom_components.myhome.sensor.er.async_get", return_value=MagicMock()), \
+         patch("custom_components.myhome.sensor.er.async_entries_for_config_entry", return_value=[]):
+        await async_setup_entry(hass, mock_config_entry, mock_add_entities)
+
+    assert len(discovered_entities) == 0
+    assert len(dispatch_callbacks) == 1
+    handle_message = dispatch_callbacks[0]
+
+    # 1. Dispatch probe 100 frame 1 from Issue #264: *#4*100*15*1*0200*0001##
+    msg1 = OWNEvent.parse("*#4*100*15*1*0200*0001##")
+    handle_message(msg1)
+
+    assert len(discovered_entities) == 1
+    probe_sensor: MyHOMETemperatureSensor = discovered_entities[0]
+    assert probe_sensor._where == "100"
+    assert probe_sensor._device_id == "100"
+    assert probe_sensor.native_unit_of_measurement == UnitOfTemperature.CELSIUS
+    assert probe_sensor.native_value == 20.0
+    assert probe_sensor.name == "Probe 100 Temperature"
+    assert probe_sensor.unique_id == f"{mac}-100-temperature"
+
+    # 2. Dispatch subsequent update: *#4*100*15*1*0196*0001## (19.6°C)
+    msg2 = OWNEvent.parse("*#4*100*15*1*0196*0001##")
+    handle_message(msg2)
+
+    # Should not create duplicate entity
+    assert len(discovered_entities) == 1
+    assert probe_sensor.native_value == 19.6
+
+    # 3. Dispatch negative temperature probe reading: *#4*100*15*1*1050*0001## (-5.0°C)
+    msg_neg = OWNEvent.parse("*#4*100*15*1*1050*0001##")
+    handle_message(msg_neg)
+    assert len(discovered_entities) == 1
+    assert probe_sensor.native_value == -5.0
+
+
+@pytest.mark.asyncio
+async def test_probe_dimension_0_discovery(mock_gateway, mock_config_entry):
+    """Test that probe address >= 100 reporting via dimension 0 also auto-discovers."""
+    mac = mock_gateway.mac
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"sensor": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+
+    discovered_entities = []
+
+    def mock_add_entities(entities):
+        discovered_entities.extend(entities)
+
+    dispatch_callbacks = []
+
+    def mock_dispatcher_connect(hass, signal, target):
+        if signal == f"myhome_message_{mac}":
+            dispatch_callbacks.append(target)
+        return MagicMock()
+
+    with patch("custom_components.myhome.sensor.async_dispatcher_connect", side_effect=mock_dispatcher_connect), \
+         patch("custom_components.myhome.sensor.er.async_get", return_value=MagicMock()), \
+         patch("custom_components.myhome.sensor.er.async_entries_for_config_entry", return_value=[]):
+        await async_setup_entry(hass, mock_config_entry, mock_add_entities)
+
+    handle_message = dispatch_callbacks[0]
+
+    # Secondary probe 105 reporting 21.5°C via dimension 0
+    msg = OWNEvent.parse("*#4*105*0*0215##")
+    handle_message(msg)
+
+    assert len(discovered_entities) == 1
+    sensor = discovered_entities[0]
+    assert sensor._where == "105"
+    assert sensor.native_value == 21.5
+    assert sensor.name == "Probe 105 Temperature"
+
+
+@pytest.mark.asyncio
+async def test_actuators_and_valves_do_not_discover_temperature_sensor(mock_gateway, mock_config_entry):
+    """Test that actuator (dim 20) and valve (dim 19) frames for address >= 100 do not create sensors."""
+    mac = mock_gateway.mac
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"sensor": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+
+    discovered_entities = []
+
+    def mock_add_entities(entities):
+        discovered_entities.extend(entities)
+
+    dispatch_callbacks = []
+
+    def mock_dispatcher_connect(hass, signal, target):
+        if signal == f"myhome_message_{mac}":
+            dispatch_callbacks.append(target)
+        return MagicMock()
+
+    with patch("custom_components.myhome.sensor.async_dispatcher_connect", side_effect=mock_dispatcher_connect), \
+         patch("custom_components.myhome.sensor.er.async_get", return_value=MagicMock()), \
+         patch("custom_components.myhome.sensor.er.async_entries_for_config_entry", return_value=[]):
+        await async_setup_entry(hass, mock_config_entry, mock_add_entities)
+
+    handle_message = dispatch_callbacks[0]
+
+    # Actuator status: *#4*100#1*20*1##
+    actuator_msg = OWNHeatingEvent("*#4*100#1*20*1##")
+    handle_message(actuator_msg)
+    assert len(discovered_entities) == 0
+
+    # Valve status: *#4*100*19*0*0##
+    valve_msg = OWNHeatingEvent("*#4*100*19*0*0##")
+    handle_message(valve_msg)
+    assert len(discovered_entities) == 0
+
+    # Fan status: *#4*100*11*1##
+    fan_msg = OWNHeatingEvent("*#4*100*11*1##")
+    handle_message(fan_msg)
+    assert len(discovered_entities) == 0
+
+
+@pytest.mark.asyncio
+async def test_temperature_registry_restoration(mock_gateway, mock_config_entry):
+    """Test that previously discovered temperature probe entries in the entity registry are restored."""
+    mac = mock_gateway.mac
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {
+        DOMAIN: {
+            mac: {
+                CONF_PLATFORMS: {"sensor": {}},
+                CONF_ENTITY: mock_gateway,
+            }
+        }
+    }
+
+    discovered_entities = []
+
+    def mock_add_entities(entities):
+        discovered_entities.extend(entities)
+
+    reg_entry1 = MagicMock()
+    reg_entry1.domain = "sensor"
+    reg_entry1.unique_id = f"{mac}-100-temperature"
+    reg_entry1.entity_id = "sensor.custom_probe_name"
+    reg_entry1.original_device_class = SensorDeviceClass.TEMPERATURE
+
+    # Second entry is duplicate for same address, should be skipped
+    reg_entry2 = MagicMock()
+    reg_entry2.domain = "sensor"
+    reg_entry2.unique_id = f"{mac}-100-temperature"
+    reg_entry2.entity_id = "sensor.custom_probe_name_duplicate"
+    reg_entry2.original_device_class = SensorDeviceClass.TEMPERATURE
+
+    with patch("custom_components.myhome.sensor.er.async_get", return_value=MagicMock()), \
+         patch("custom_components.myhome.sensor.er.async_entries_for_config_entry", return_value=[reg_entry1, reg_entry2]), \
+         patch("custom_components.myhome.sensor.async_dispatcher_connect", return_value=MagicMock()):
+        await async_setup_entry(hass, mock_config_entry, mock_add_entities)
+
+    assert len(discovered_entities) == 1
+    sensor = discovered_entities[0]
+    assert sensor.entity_id == "sensor.custom_probe_name"
+    assert sensor._where == "100"
+
+
+@pytest.mark.asyncio
+async def test_temperature_sensor_async_update_and_events(mock_gateway):
+    """Test MyHOMETemperatureSensor async_update and event handling."""
+    hass = MagicMock()
+    sensor = MyHOMETemperatureSensor(
+        hass=hass,
+        name="Probe 100",
+        device_id="100",
+        who="4",
+        where="100",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        manufacturer="BTicino",
+        model="Temperature Probe",
+        gateway=mock_gateway,
+    )
+
+    # async_update for probe >= 100
+    await sensor.async_update()
+    mock_gateway.send_status_request.assert_called_once()
+    called_cmd = mock_gateway.send_status_request.call_args[0][0]
+    assert str(called_cmd) in ("*#4*100*15##", "*#4*100*0##")
+
+    # async_update for zone < 100
+    sensor_zone = MyHOMETemperatureSensor(
+        hass=hass,
+        name="Zone 2",
+        device_id="2",
+        who="4",
+        where="2",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        manufacturer="BTicino",
+        model="Thermostat",
+        gateway=mock_gateway,
+    )
+    mock_gateway.send_status_request.reset_mock()
+    await sensor_zone.async_update()
+    mock_gateway.send_status_request.assert_called_once()
+    assert str(mock_gateway.send_status_request.call_args[0][0]) == "*#4*2*0##"
+
+    # Event handling with dimension 15 fallback (positive)
+    mock_event = MagicMock(spec=OWNHeatingEvent)
+    mock_event.message_type = None
+    mock_event.dimension = 15
+    mock_event.dimension_value = ["1", "0205", "0001"]
+    mock_event.human_readable_log = "Probe reporting 20.5"
+
+    sensor.async_schedule_update_ha_state = MagicMock()
+    sensor.handle_event(mock_event)
+    assert sensor._attr_native_value == 20.5
+    sensor.async_schedule_update_ha_state.assert_called_once()
+
+    # Event handling with dimension 15 fallback (negative)
+    mock_event_neg = MagicMock(spec=OWNHeatingEvent)
+    mock_event_neg.message_type = None
+    mock_event_neg.dimension = 15
+    mock_event_neg.dimension_value = ["1", "1025", "0001"]
+    mock_event_neg.human_readable_log = "Probe reporting -2.5"
+    sensor.handle_event(mock_event_neg)
+    assert sensor._attr_native_value == -2.5
+
+    # Event handling with dimension 15 fallback (invalid value does not crash)
+    mock_event_invalid = MagicMock(spec=OWNHeatingEvent)
+    mock_event_invalid.message_type = None
+    mock_event_invalid.dimension = 15
+    mock_event_invalid.dimension_value = ["1", "invalid", "0001"]
+    sensor.handle_event(mock_event_invalid)
+    assert sensor._attr_native_value == -2.5
+
+    # Event handling with secondary_temperature as float
+    mock_event_sec_float = MagicMock(spec=OWNHeatingEvent)
+    mock_event_sec_float.message_type = MESSAGE_TYPE_SECONDARY_TEMPERATURE
+    mock_event_sec_float.secondary_temperature = 18.5
+    sensor.handle_event(mock_event_sec_float)
+    assert sensor._attr_native_value == 18.5
+
+    # Event handling with probe_temperature attribute and no secondary_temperature list
+    class MockProbeEvent:
+        message_type = MESSAGE_TYPE_SECONDARY_TEMPERATURE
+        secondary_temperature = None
+        probe_temperature = 23.4
+        human_readable_log = "Probe reporting 23.4"
+
+    sensor.handle_event(MockProbeEvent())
+    assert sensor._attr_native_value == 23.4
+
+    # Event handling with dimension 0 fallback (positive and negative)
+    mock_dim0_pos = MagicMock(spec=OWNHeatingEvent)
+    mock_dim0_pos.message_type = None
+    mock_dim0_pos.dimension = 0
+    mock_dim0_pos.dimension_value = ["0215"]
+    mock_dim0_pos.human_readable_log = "Dim 0 reporting 21.5"
+    sensor.handle_event(mock_dim0_pos)
+    assert sensor._attr_native_value == 21.5
+
+    mock_dim0_neg = MagicMock(spec=OWNHeatingEvent)
+    mock_dim0_neg.message_type = None
+    mock_dim0_neg.dimension = 0
+    mock_dim0_neg.dimension_value = ["1045"]
+    mock_dim0_neg.human_readable_log = "Dim 0 reporting -4.5"
+    sensor.handle_event(mock_dim0_neg)
+    assert sensor._attr_native_value == -4.5
+
+    mock_dim0_invalid = MagicMock(spec=OWNHeatingEvent)
+    mock_dim0_invalid.message_type = None
+    mock_dim0_invalid.dimension = 0
+    mock_dim0_invalid.dimension_value = ["invalid"]
+    sensor.handle_event(mock_dim0_invalid)
+    assert sensor._attr_native_value == -4.5
+
+    # Unhandled dimension returns True
+    unhandled = MagicMock(spec=OWNHeatingEvent)
+    unhandled.message_type = "other"
+    unhandled.dimension = 20
+    assert sensor.handle_event(unhandled) is True


### PR DESCRIPTION
## Description
Resolves #264.

Companion PR to [OpenWebNet-HA/OWNd#29](https://github.com/OpenWebNet-HA/OWNd/pull/29).

### Context & Root Cause
In `2.0.0b1`, climate dynamic discovery captured WHO=4 traffic and mistook temperature probes (`WHERE >= 100`, e.g. probe `100` reporting `*#4*100*15*1*0200*0001##`) for climate thermostats, crashing Home Assistant startup with `ValueError: 'unknown' is not a valid HVACMode`. PR #265 excluded addresses >= 100 from `climate.py` to fix the crash. However, `sensor.py` historically only supported auto-discovery for energy/power meters (WHO 18) and illuminance sensors (WHO 1), leaving temperature probes without discovery. Furthermore, probe telemetry frames use WHO 4 Dimension 15 (`*#4*WHERE*15*VAL1*VAL2*VAL3##`), which required parser support in `OWNd`.

### Changes
1. **Dynamic Probe Discovery (`custom_components/myhome/sensor.py`)**:
   - Added `discover_temperature_sensor(where, entity_id=None)` to automatically discover probe entities with name `Probe {where} Temperature` and unique ID `{mac}-{where}-temperature`.
   - In `handle_message`: detects `OWNHeatingEvent` carrying temperature readings (dimension 15, `secondary_temperature`, or dimension 0 for probe addresses >= 100).
   - Distinguishes probe readings from actuator status (dimension 20), valve status (dimension 19), and fan speed (dimension 11) to avoid false sensor creation.
   - Synchronously adds the discovered sensor before scheduling addition to prevent race conditions or missed initial readings during frame bursts.
2. **Entity Registry Restoration**:
   - Restores existing probe sensor entries from the entity registry on setup (`entry.original_device_class == SensorDeviceClass.TEMPERATURE` or `-temperature` unique ID suffix), preserving user entity IDs and custom friendly names.
3. **Telemetry & Status Request Handling in `MyHOMETemperatureSensor`**:
   - `handle_event`: updates `_attr_native_value` from `secondary_temperature`, `probe_temperature`, or raw dimension 15 / dimension 0 fallbacks (including positive and negative temperature encoding).
   - `async_update`: requests `OWNHeatingCommand.get_probe_temperature(self._where)` (`*#4*{where}*15##`) for probe addresses >= 100.
4. **Test Suite (`tests/test_issue_264.py`)**:
   - Comprehensive unit tests covering probe dimension 15 discovery and updates (`*#4*100*15*1*0200*0001##` -> 20.0°C, `*#4*100*15*1*0196*0001##` -> 19.6°C, negative temperatures), dimension 0 discovery, actuator/valve exclusion, entity registry restoration, and `async_update`.
   - Achieves 100% test coverage on `custom_components/myhome/sensor.py`.