### PR TITLE
fix(frontend): add WHO=5 filter and generalize card field filtering (#275)

### DIFF
--- a/custom_components/myhome/frontend/myhome-bus-card.js
+++ b/custom_components/myhome/frontend/myhome-bus-card.js
@@ -5,6 +5,30 @@
  * for BTicino / Legrand MyHOME SCS bus systems via OpenWebNet.
  */
 
+const WHO_CATALOG = {
+  "0": { name: "Scenarios (Basic)", short: "Scenario", class: "who-cen" },
+  "1": { name: "Lighting / Switches", short: "Light/Switch", class: "who-light" },
+  "2": { name: "Automation / Shutters", short: "Automation", class: "who-cover" },
+  "3": { name: "Load Control", short: "Load Ctrl", class: "who-energy" },
+  "4": { name: "Heating / Thermoregulation", short: "Heating", class: "who-thermo" },
+  "5": { name: "Burglar Alarm", short: "Burglar Alarm", class: "who-alarm" },
+  "6": { name: "Door Entry / Access Control", short: "Door Entry", class: "who-access" },
+  "7": { name: "Video Door Entry / Multimedia", short: "Video Entry", class: "who-video" },
+  "9": { name: "Auxiliary", short: "Auxiliary", class: "who-default" },
+  "13": { name: "Gateway Management", short: "Gateway", class: "who-diag" },
+  "14": { name: "Actuator Diagnostics & Lock", short: "Actuator Lock", class: "who-diag" },
+  "15": { name: "CEN Pushbuttons", short: "CEN", class: "who-cen" },
+  "16": { name: "Sound System", short: "Sound", class: "who-sound" },
+  "17": { name: "Scenario Management / MH200N", short: "MH200N", class: "who-cen" },
+  "18": { name: "Energy Management", short: "Energy", class: "who-energy" },
+  "22": { name: "Sound Diffusion Extended", short: "Sound Ext", class: "who-sound" },
+  "24": { name: "Lighting Management / DALI", short: "DALI Light", class: "who-light" },
+  "25": { name: "CEN+ / Security", short: "CEN+/Sec", class: "who-cen" },
+  "1001": { name: "Lighting Diagnostics", short: "Diag Light", class: "who-diag" },
+  "1004": { name: "Heating Diagnostics", short: "Diag Heat", class: "who-diag" },
+  "1013": { name: "Gateway Diagnostics", short: "Diag Gateway", class: "who-diag" },
+};
+
 class MyHomeBusCard extends HTMLElement {
   constructor() {
     super();
@@ -113,6 +137,9 @@ class MyHomeBusCard extends HTMLElement {
         const newHistory = res.frames.filter(
           (f) => !existingKeys.has(`${f.timestamp}_${f.raw}_${f.direction}`)
         );
+        for (const f of newHistory) {
+          if (f.who != null) this._ensureWhoRegistered(f.who);
+        }
         this._frames = newHistory.concat(this._frames);
         if (this._frames.length > this._maxDisplayFrames) {
           this._frames = this._frames.slice(-this._maxDisplayFrames);
@@ -212,11 +239,49 @@ class MyHomeBusCard extends HTMLElement {
     }
   }
 
+  _ensureWhoRegistered(who) {
+    if (who == null || String(who).trim() === "") return;
+    const whoStr = String(who).trim();
+    const select = this.shadowRoot && this.shadowRoot.getElementById("filter-who");
+    if (!select) return;
+
+    for (let i = 0; i < select.options.length; i++) {
+      if (select.options[i].value === whoStr) return;
+    }
+
+    const catalogEntry = WHO_CATALOG[whoStr];
+    const label = catalogEntry
+      ? `${catalogEntry.name} (WHO=${whoStr})`
+      : `Subsystem (WHO=${whoStr})`;
+
+    const opt = document.createElement("option");
+    opt.value = whoStr;
+    opt.textContent = label;
+
+    const whoNum = parseInt(whoStr, 10);
+    let inserted = false;
+    for (let i = 1; i < select.options.length; i++) {
+      const curNum = parseInt(select.options[i].value, 10);
+      if (!isNaN(whoNum) && !isNaN(curNum) && whoNum < curNum) {
+        select.insertBefore(opt, select.options[i]);
+        inserted = true;
+        break;
+      }
+    }
+    if (!inserted) {
+      select.appendChild(opt);
+    }
+  }
+
   _onNewFrame(frame) {
     if (this._connectionStatus !== "connected" && !this._isPaused) {
       this._updateConnectionStatus("connected");
     }
     if (this._isPaused) return;
+
+    if (frame.who != null) {
+      this._ensureWhoRegistered(frame.who);
+    }
 
     if (frame.direction === "rx") this._stats.total_rx++;
     else this._stats.total_tx++;
@@ -232,45 +297,100 @@ class MyHomeBusCard extends HTMLElement {
   }
 
   _matchesFilter(frame) {
-    if (this._filterDir !== "all" && frame.direction !== this._filterDir) {
-      return false;
+    if (this._filterDir !== "all") {
+      const dir = (frame.direction || "").toLowerCase();
+      if (this._filterDir === "rx" && dir !== "rx") return false;
+      if (this._filterDir === "tx" && dir !== "tx") return false;
+      if (this._filterDir === "ack" && !frame.is_ack) return false;
+      if (this._filterDir === "nack" && !frame.is_nack) return false;
     }
     if (this._filterWho !== "all" && String(frame.who) !== String(this._filterWho)) {
       return false;
     }
-    if (this._filterWhere && !String(frame.where || "").toLowerCase().includes(this._filterWhere.toLowerCase())) {
-      return false;
+    if (this._filterWhere) {
+      const q = this._filterWhere.trim().toLowerCase();
+      if (q) {
+        if (q.startsWith("where:") || q.startsWith("where=")) {
+          const val = q.substring(6).trim();
+          if (!String(frame.where || "").toLowerCase().includes(val)) return false;
+        } else if (q.startsWith("what:") || q.startsWith("what=")) {
+          const val = q.substring(5).trim();
+          if (!String(frame.what || "").toLowerCase().includes(val)) return false;
+        } else if (q.startsWith("dim:") || q.startsWith("dim=")) {
+          const val = q.substring(4).trim();
+          if (!String(frame.dimension || "").toLowerCase().includes(val)) return false;
+        } else if (q.startsWith("raw:") || q.startsWith("raw=")) {
+          const val = q.substring(4).trim();
+          if (!String(frame.raw || "").toLowerCase().includes(val)) return false;
+        } else {
+          const inWhere = String(frame.where || "").toLowerCase().includes(q);
+          const inRaw = String(frame.raw || "").toLowerCase().includes(q);
+          const inWhat = String(frame.what || "").toLowerCase().includes(q);
+          const inDim = String(frame.dimension || "").toLowerCase().includes(q);
+          if (!inWhere && !inRaw && !inWhat && !inDim) return false;
+        }
+      }
     }
     return true;
   }
 
   _formatWho(who) {
-    const map = {
-      "1": "Light/Switch",
-      "2": "Automation",
-      "4": "Heating",
-      "15": "CEN",
-      "16": "Sound",
-      "18": "Energy",
-      "25": "CEN+/Sec",
-    };
-    return map[String(who)] || (who ? `WHO=${who}` : "Sys");
+    if (who == null || String(who).trim() === "") return "Sys";
+    const strWho = String(who).trim();
+    const entry = WHO_CATALOG[strWho];
+    if (entry && entry.short) return entry.short;
+    if (entry && entry.name) return entry.name;
+    return `WHO=${strWho}`;
   }
 
   _getWhoClass(who) {
-    switch (String(who)) {
-      case "1": return "who-light";
-      case "2": return "who-cover";
-      case "4": return "who-thermo";
-      case "15":
-      case "25": return "who-cen";
-      case "16": return "who-sound";
-      case "18": return "who-energy";
-      default: return "who-default";
+    if (who == null) return "who-default";
+    const entry = WHO_CATALOG[String(who).trim()];
+    if (entry && entry.class) return entry.class;
+    return "who-default";
+  }
+
+  _getWhoBadgeStyle(who) {
+    if (who == null || String(who).trim() === "") return "";
+    const str = String(who).trim();
+    if (WHO_CATALOG[str] && WHO_CATALOG[str].class !== "who-default") {
+      return "";
     }
+    const num = parseInt(str, 10);
+    const hue = !isNaN(num) ? (num * 137.5) % 360 : 200;
+    return `style="background: hsl(${hue}, 45%, 18%); color: hsl(${hue}, 85%, 75%);"`;
   }
 
   _render() {
+    const sortedWhoKeys = Object.keys(WHO_CATALOG).sort((a, b) => {
+      const na = parseInt(a, 10);
+      const nb = parseInt(b, 10);
+      if (!isNaN(na) && !isNaN(nb)) return na - nb;
+      return a.localeCompare(b);
+    });
+
+    const optionsList = [
+      `<option value="all"${this._filterWho === "all" ? " selected" : ""}>All Subsystems</option>`
+    ];
+    for (const key of sortedWhoKeys) {
+      const item = WHO_CATALOG[key];
+      const sel = String(this._filterWho) === key ? " selected" : "";
+      optionsList.push(`<option value="${key}"${sel}>${item.name} (WHO=${key})</option>`);
+    }
+
+    const seenWhos = new Set(sortedWhoKeys);
+    for (const f of this._frames) {
+      if (f.who != null) {
+        const wStr = String(f.who).trim();
+        if (wStr && !seenWhos.has(wStr)) {
+          seenWhos.add(wStr);
+          const sel = String(this._filterWho) === wStr ? " selected" : "";
+          optionsList.push(`<option value="${wStr}"${sel}>Subsystem (WHO=${wStr})</option>`);
+        }
+      }
+    }
+    const whoOptionsHtml = optionsList.join("\n            ");
+
     this.shadowRoot.innerHTML = `
       <style>
         :host {
@@ -406,9 +526,13 @@ class MyHomeBusCard extends HTMLElement {
         .who-light { background: #4a3b00; color: #ffe082; }
         .who-cover { background: #0d47a1; color: #90caf9; }
         .who-thermo { background: #b71c1c; color: #ef9a9a; }
+        .who-alarm { background: #880e4f; color: #f48fb1; }
         .who-cen { background: #4a148c; color: #ce93d8; }
         .who-sound { background: #004d40; color: #80cbc4; }
         .who-energy { background: #006064; color: #80deea; }
+        .who-access { background: #bf360c; color: #ffcc80; }
+        .who-video { background: #1a237e; color: #c5cae9; }
+        .who-diag { background: #263238; color: #cfd8dc; }
         .who-default { background: #37474f; color: #b0bec5; }
         .col-raw { color: #fff; word-break: break-all; }
         .raw-ack { color: #69f0ae; font-weight: 600; }
@@ -493,22 +617,17 @@ class MyHomeBusCard extends HTMLElement {
 
         <div class="controls">
           <select id="filter-who">
-            <option value="all">All Subsystems</option>
-            <option value="1">Lighting / Switches (WHO=1)</option>
-            <option value="2">Automation / Shutters (WHO=2)</option>
-            <option value="4">Heating / Thermoregulation (WHO=4)</option>
-            <option value="15">CEN Pushbuttons (WHO=15)</option>
-            <option value="16">Sound System (WHO=16)</option>
-            <option value="18">Energy Management (WHO=18)</option>
-            <option value="25">CEN+ / Security (WHO=25)</option>
+            ${whoOptionsHtml}
           </select>
 
-          <input type="text" id="filter-where" placeholder="Filter WHERE (e.g. 12)..." style="width: 140px;" />
+          <input type="text" id="filter-where" placeholder="Filter WHERE / WHAT / Raw..." value="${this._escapeHtml(this._filterWhere)}" style="width: 170px;" />
 
           <select id="filter-dir">
-            <option value="all">All Directions</option>
-            <option value="rx">RX (Bus Traffic)</option>
-            <option value="tx">TX (Commands)</option>
+            <option value="all"${this._filterDir === "all" ? " selected" : ""}>All Directions</option>
+            <option value="rx"${this._filterDir === "rx" ? " selected" : ""}>RX (Bus Traffic)</option>
+            <option value="tx"${this._filterDir === "tx" ? " selected" : ""}>TX (Commands)</option>
+            <option value="ack"${this._filterDir === "ack" ? " selected" : ""}>ACK (*#*1##)</option>
+            <option value="nack"${this._filterDir === "nack" ? " selected" : ""}>NACK (*#*0##)</option>
           </select>
         </div>
 
@@ -863,6 +982,7 @@ ${framesText}
     const dirLabel = frame.direction ? frame.direction.toUpperCase() : "RX";
     const whoClass = this._getWhoClass(frame.who);
     const whoLabel = this._formatWho(frame.who);
+    const whoCustomStyle = this._getWhoBadgeStyle(frame.who);
 
     let rawClass = "col-raw";
     if (frame.is_ack) rawClass += " raw-ack";
@@ -871,7 +991,7 @@ ${framesText}
     div.innerHTML = `
       <span class="col-time">${timeStr}</span>
       <span class="col-dir ${dirClass}">${dirLabel}</span>
-      <span class="col-who ${whoClass}">${whoLabel}</span>
+      <span class="col-who ${whoClass}" ${whoCustomStyle}>${this._escapeHtml(whoLabel)}</span>
       <span class="${rawClass}">${this._escapeHtml(frame.raw)}</span>
     `;
     return div;

--- a/custom_components/myhome/websocket.py
+++ b/custom_components/myhome/websocket.py
@@ -45,7 +45,7 @@ SCHEMA_WS_HISTORY = {
     vol.Optional("limit", default=100): vol.All(vol.Coerce(int), vol.Range(min=1, max=500)),
     vol.Optional("who"): vol.Any(cv.string, vol.Coerce(int), None),
     vol.Optional("where"): vol.Any(cv.string, None),
-    vol.Optional("direction"): vol.Any(vol.In(["rx", "tx", "all"]), None),
+    vol.Optional("direction"): vol.Any(vol.In(["rx", "tx", "ack", "nack", "all"]), None),
 }
 
 SCHEMA_WS_STREAM = {
@@ -53,7 +53,7 @@ SCHEMA_WS_STREAM = {
     vol.Optional("mac"): vol.Any(cv.string, None),
     vol.Optional("who"): vol.Any(cv.string, vol.Coerce(int), None),
     vol.Optional("where"): vol.Any(cv.string, None),
-    vol.Optional("direction"): vol.Any(vol.In(["rx", "tx", "all"]), None),
+    vol.Optional("direction"): vol.Any(vol.In(["rx", "tx", "ack", "nack", "all"]), None),
 }
 
 SCHEMA_WS_SEND = {
@@ -247,9 +247,17 @@ def _matches_filter(
     raw_who = getattr(frame, "who", None) if isinstance(frame, BusFrame) else frame.get("who")
     raw_where = getattr(frame, "where", None) if isinstance(frame, BusFrame) else frame.get("where")
     f_dir = (getattr(frame, "direction", "") if isinstance(frame, BusFrame) else frame.get("direction", "")).lower()
+    is_ack = getattr(frame, "is_ack", False) if isinstance(frame, BusFrame) else frame.get("is_ack", False)
+    is_nack = getattr(frame, "is_nack", False) if isinstance(frame, BusFrame) else frame.get("is_nack", False)
 
-    if direction and direction != "all" and f_dir != direction.lower():
-        return False
+    if direction and direction != "all":
+        d_lower = direction.lower()
+        if d_lower in ("rx", "tx") and f_dir != d_lower:
+            return False
+        if d_lower == "ack" and not is_ack:
+            return False
+        if d_lower == "nack" and not is_nack:
+            return False
 
     if who is not None and str(who) != "all":
         if raw_who is None or str(who) != str(raw_who):

--- a/tests/test_issue_275.py
+++ b/tests/test_issue_275.py
@@ -1,0 +1,132 @@
+"""Unit tests for Issue #275: WHO=5 filter support and generalized card field filtering."""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+from OWNd.message import OWNEvent, OWNSignaling
+
+from custom_components.myhome.bus_monitor import BusFrame, BusMonitor
+from custom_components.myhome.const import CONF_ENTITY, DOMAIN
+from custom_components.myhome.websocket import (
+    _matches_filter,
+    ws_bus_monitor_history,
+)
+
+
+@pytest.fixture
+def mock_ws_connection():
+    """Create a mock active WebSocket connection."""
+    conn = MagicMock(spec=websocket_api.ActiveConnection)
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    conn.send_message = MagicMock()
+    conn.subscriptions = {}
+    return conn
+
+
+def test_card_js_contains_who_5_and_generalization():
+    """Verify frontend custom card contains WHO=5 Burglar Alarm and generalized field handling."""
+    card_path = Path("custom_components/myhome/frontend/myhome-bus-card.js")
+    assert card_path.exists(), "myhome-bus-card.js must exist"
+
+    content = card_path.read_text(encoding="utf-8")
+
+    # 1. Verify WHO_CATALOG contains WHO=5
+    assert '"5": { name: "Burglar Alarm"' in content
+    assert 'class: "who-alarm"' in content
+
+    # 2. Verify CSS styling for .who-alarm exists
+    assert ".who-alarm" in content
+
+    # 3. Verify dynamic WHO auto-registration method exists
+    assert "_ensureWhoRegistered" in content
+
+    # 4. Verify generalized multi-field search logic exists
+    assert 'q.startsWith("where:")' in content or 'query.startsWith("where:")' in content
+    assert 'q.startsWith("what:")' in content or 'query.startsWith("what:")' in content
+    assert 'q.startsWith("dim:")' in content or 'query.startsWith("dim:")' in content
+    assert 'q.startsWith("raw:")' in content or 'query.startsWith("raw:")' in content
+
+    # 5. Verify ACK and NACK options in direction filter
+    assert 'value="ack"' in content
+    assert 'value="nack"' in content
+
+
+def test_backend_filter_matches_who_5():
+    """Verify backend _matches_filter accurately matches WHO=5 frames."""
+    alarm_msg = OWNEvent.parse("*5*1*0##")
+    frame = BusFrame(direction="rx", raw="*5*1*0##", parsed=alarm_msg)
+
+    # Frame who is 5
+    assert frame.who == 5 or frame.who == "5"
+
+    # Matches when who="5" or 5
+    assert _matches_filter(frame, who="5") is True
+    assert _matches_filter(frame, who=5) is True
+
+    # Rejects when who is a different subsystem
+    assert _matches_filter(frame, who="1") is False
+    assert _matches_filter(frame, who="2") is False
+
+    # Matches "all"
+    assert _matches_filter(frame, who="all") is True
+
+
+def test_backend_filter_ack_nack_direction():
+    """Verify backend _matches_filter supports direction='ack' and 'nack'."""
+    ack_frame = BusFrame(direction="rx", raw="*#*1##", parsed=OWNSignaling("*#*1##"))
+    nack_frame = BusFrame(direction="rx", raw="*#*0##", parsed=OWNSignaling("*#*0##"))
+    normal_frame = BusFrame(direction="rx", raw="*1*1*12##", parsed=OWNEvent.parse("*1*1*12##"))
+
+    assert _matches_filter(ack_frame, direction="ack") is True
+    assert _matches_filter(ack_frame, direction="nack") is False
+    assert _matches_filter(ack_frame, direction="rx") is True
+
+    assert _matches_filter(nack_frame, direction="nack") is True
+    assert _matches_filter(nack_frame, direction="ack") is False
+    assert _matches_filter(nack_frame, direction="rx") is True
+
+    assert _matches_filter(normal_frame, direction="ack") is False
+    assert _matches_filter(normal_frame, direction="nack") is False
+
+
+async def test_ws_history_with_who_5(hass: HomeAssistant, mock_ws_connection):
+    """Test history request returns frames filtered specifically by WHO=5."""
+    monitor = BusMonitor(maxlen=100)
+    gateway = MagicMock()
+    mac = "00:03:50:00:12:34"
+    hass.data[DOMAIN] = {
+        mac: {
+            CONF_ENTITY: gateway,
+            "bus_monitor": monitor,
+        }
+    }
+
+    # Record mixed frames: light (WHO=1), automation (WHO=2), alarm (WHO=5)
+    ev_light = OWNEvent.parse("*1*1*12##")
+    ev_cover = OWNEvent.parse("*2*1*21##")
+    ev_alarm1 = OWNEvent.parse("*5*1*0##")
+    ev_alarm2 = OWNEvent.parse("*5*0*0##")
+
+    monitor.record_frame("rx", "*1*1*12##", ev_light)
+    monitor.record_frame("tx", "*2*1*21##", ev_cover)
+    monitor.record_frame("rx", "*5*1*0##", ev_alarm1)
+    monitor.record_frame("tx", "*5*0*0##", ev_alarm2)
+
+    # Filter specifically by WHO=5
+    ws_bus_monitor_history(
+        hass,
+        mock_ws_connection,
+        {"id": 42, "type": "myhome/bus_monitor/history", "who": "5"},
+    )
+    await hass.async_block_till_done()
+
+    mock_ws_connection.send_result.assert_called_once()
+    msg_id, result = mock_ws_connection.send_result.call_args[0]
+    assert msg_id == 42
+    assert len(result["frames"]) == 2
+    assert all(f["who"] == "5" for f in result["frames"])
+    assert result["frames"][0]["raw"] == "*5*1*0##"
+    assert result["frames"][1]["raw"] == "*5*0*0##"


### PR DESCRIPTION
## Summary

Resolves #275.

In #275, @TheDarkWizard reported that the MyHOME Bus Monitor custom card (`myhome-bus-card.js`) lacked the `WHO=5` (Burglar Alarm / Antifurto) filter option in the subsystem dropdown.

This PR adds `WHO=5` with dedicated badge formatting and color styling (`.who-alarm`), and **generalizes the card's architecture** to make subsystem and field filtering fully dynamic and future-proof.

---

### Key Improvements

1. **Master OpenWebNet Subsystem Catalog (`WHO_CATALOG`)**:
   - Embedded the full official catalog covering all standard OpenWebNet WHO families:
     - `WHO=0`: Scenarios (Basic)
     - `WHO=1`: Lighting / Switches
     - `WHO=2`: Automation / Shutters
     - `WHO=3`: Load Control
     - `WHO=4`: Heating / Thermoregulation
     - `WHO=5`: Burglar Alarm
     - `WHO=6`: Door Entry / Access Control
     - `WHO=7`: Video Door Entry / Multimedia
     - `WHO=9`: Auxiliary
     - `WHO=13`: Gateway Management
     - `WHO=14`: Actuator Diagnostics & Lock
     - `WHO=15`: CEN Pushbuttons
     - `WHO=16`: Sound System
     - `WHO=17`: Scenario Management / MH200N
     - `WHO=18`: Energy Management
     - `WHO=22`: Sound Diffusion Extended
     - `WHO=24`: Lighting Management / DALI
     - `WHO=25`: CEN+ / Security
     - `WHO=1001`: Lighting Diagnostics
     - `WHO=1004`: Heating Diagnostics
     - `WHO=1013`: Gateway Diagnostics

2. **Dynamic On-The-Fly WHO Auto-Registration (`_ensureWhoRegistered`)**:
   - When historical or live stream frames arrive containing any WHO not yet in the select dropdown (e.g. custom, uncataloged, or future firmware subsystems), the card automatically inserts a new sorted option (`Subsystem (WHO=X)`) into the dropdown without resetting user selections.
   - Uncataloged / custom WHO numbers automatically receive deterministic, high-contrast dark-mode HSL badge colors based on their numeric value.
   - Added dedicated CSS badge classes: `.who-alarm` (deep ruby/crimson `#880e4f`), `.who-access`, `.who-video`, `.who-diag`.

3. **Multi-Field Search & Prefix Filtering (`_matchesFilter`)**:
   - Search input now searches across `WHERE`, `WHAT`, `DIMENSION`, and `RAW` frame contents.
   - Supports explicit prefix queries (e.g. `what:1`, `dim:15`, `where:12`, `raw:*5*1*0##`) as well as general text search.

4. **ACK / NACK Direction Filtering**:
   - Added `ACK (*#*1##)` and `NACK (*#*0##)` filter options in the direction dropdown to easily isolate acknowledgments and errors.
   - Updated WebSocket schemas in `websocket.py` to allow `"ack"` and `"nack"` in `direction` and enhanced `_matches_filter`.

---

### Automated Tests

- Added `tests/test_issue_275.py`:
  - `test_card_js_contains_who_5_and_generalization`: Validates that `myhome-bus-card.js` defines `WHO=5` Burglar Alarm, `.who-alarm`, dynamic auto-registration, generalized field prefixes, and ACK/NACK filters.
  - `test_backend_filter_matches_who_5`: Validates `_matches_filter` for WHO=5 alarm frames (`*5*1*0##`, `*5*0*0##`).
  - `test_backend_filter_ack_nack_direction`: Validates `_matches_filter` support for `direction="ack"` and `direction="nack"`.
  - `test_ws_history_with_who_5`: Validates WebSocket history endpoint returns frames filtered by `who="5"`.
- Full test suite passing: **987 passed, 0 failures**.