### PR TITLE
fix(frontend): deduplicate bus card in picker and eliminate event loop warnings (#277)

### DIFF
--- a/custom_components/myhome/__init__.py
+++ b/custom_components/myhome/__init__.py
@@ -77,7 +77,7 @@ async def _async_register_lovelace_resource(hass: HomeAssistant, url_path: str) 
                     "res_type": "module",
                     "url": url_path,
                 })
-                LOGGER.debug("Auto-registered Lovelace bus monitor resource: %s", url_path)
+                LOGGER.info("Auto-registered Lovelace bus monitor resource: %s", url_path)
             elif existing_match.get("url") != url_path:
                 if hasattr(resources, "async_update_item") and "id" in existing_match:
                     await resources.async_update_item(
@@ -112,7 +112,7 @@ async def _async_register_frontend(hass: HomeAssistant) -> None:
 
     card_path = os.path.join(os.path.dirname(__file__), "frontend", "myhome-bus-card.js")
     static_url = "/myhome_static/myhome-bus-card.js"
-    versioned_url = _get_card_url(card_path, static_url)
+    versioned_url = await hass.async_add_executor_job(_get_card_url, card_path, static_url)
 
     http = getattr(hass, "http", None)
     if not domain_data.get("_frontend_registered"):
@@ -160,7 +160,7 @@ async def async_ensure_ownd_engine(hass: HomeAssistant) -> bool:
     from homeassistant.util import package as pkg_util
 
     # Fast path: requirement satisfied and currently loaded version matches
-    current_ver = get_ownd_version()
+    current_ver = await hass.async_add_executor_job(get_ownd_version)
     is_installed = pkg_util.is_installed(required_pkg)
     if is_installed and current_ver == INTEGRATION_VERSION:
         return True
@@ -177,6 +177,8 @@ async def async_ensure_ownd_engine(hass: HomeAssistant) -> bool:
         try:
             from homeassistant.requirements import async_process_requirements
             await async_process_requirements(hass, DOMAIN, [required_pkg])
+            if hasattr(get_ownd_version, "cache_clear"):
+                get_ownd_version.cache_clear()
             LOGGER.info("Successfully installed matching requirement %s", required_pkg)
         except Exception as err:
             LOGGER.error("Automatic installation of %s failed: %s", required_pkg, err)
@@ -201,6 +203,8 @@ async def async_ensure_ownd_engine(hass: HomeAssistant) -> bool:
     import importlib
     import sys
 
+    if hasattr(get_ownd_version, "cache_clear"):
+        get_ownd_version.cache_clear()
     importlib.invalidate_caches()
     for mod_name in list(sys.modules.keys()):
         if mod_name == "OWNd" or mod_name.startswith("OWNd."):
@@ -209,7 +213,7 @@ async def async_ensure_ownd_engine(hass: HomeAssistant) -> bool:
             except Exception as reload_err:  # pragma: no cover
                 LOGGER.debug("Could not reload module %s: %s", mod_name, reload_err)
 
-    new_ver = get_ownd_version()
+    new_ver = await hass.async_add_executor_job(get_ownd_version)
     LOGGER.info("Self-healing complete: OWNd engine synchronized to v%s", new_ver)
     return True
 
@@ -223,7 +227,7 @@ async def async_setup(hass, config):
     LOGGER.info(
         "Initializing MyHOME integration v%s (OWNd v%s)",
         INTEGRATION_VERSION,
-        get_ownd_version(),
+        await hass.async_add_executor_job(get_ownd_version),
     )
 
     from .websocket import async_setup_websocket_api

--- a/custom_components/myhome/frontend/myhome-bus-card.js
+++ b/custom_components/myhome/frontend/myhome-bus-card.js
@@ -1017,20 +1017,12 @@ console.info(
   "background:#263238;color:#fff;padding:2px 4px;border-radius:0 3px 3px 0;"
 );
 
-window.customCards = window.customCards || [];
+window.customCards = (window.customCards || []).filter((c) => c.type !== "myhome-bus-card");
 if (!window.customCards.some((c) => c.type === "myhome-openwebnet-bus-monitor")) {
   window.customCards.push({
     type: "myhome-openwebnet-bus-monitor",
     name: "MyHOME OpenWebNet Bus Monitor",
     description: "Real-time BTicino / Legrand SCS OpenWebNet bus traffic stream, packet inspector, and diagnostic frame sender.",
-    preview: false,
-  });
-}
-if (!window.customCards.some((c) => c.type === "myhome-bus-card")) {
-  window.customCards.push({
-    type: "myhome-bus-card",
-    name: "MyHOME Bus Card (Alias)",
-    description: "Real-time BTicino / Legrand SCS OpenWebNet bus monitor (alias for myhome-openwebnet-bus-monitor).",
     preview: false,
   });
 }

--- a/tests/test_issue_275.py
+++ b/tests/test_issue_275.py
@@ -53,6 +53,12 @@ def test_card_js_contains_who_5_and_generalization():
     assert 'value="ack"' in content
     assert 'value="nack"' in content
 
+    # 6. Verify single canonical card registration without duplicate alias in window.customCards
+    assert 'type: "myhome-openwebnet-bus-monitor"' in content
+    assert 'filter((c) => c.type !== "myhome-bus-card")' in content
+    assert 'customElements.define("myhome-bus-card"' in content
+    assert 'name: "MyHOME Bus Card (Alias)"' not in content
+
 
 def test_backend_filter_matches_who_5():
     """Verify backend _matches_filter accurately matches WHO=5 frames."""


### PR DESCRIPTION
## Summary of Changes

Resolves #277.

This PR addresses frontend card duplication and event loop warnings in `v2.0.0b5`:

1. **Card Picker Deduplication**:
   - In `custom_components/myhome/frontend/myhome-bus-card.js`, both `myhome-openwebnet-bus-monitor` and `myhome-bus-card` were being pushed to `window.customCards`, resulting in two card entries in Home Assistant's card picker (`+ Add Card` -> `By card`).
   - Pruned `myhome-bus-card` from `window.customCards` so only the canonical card **`MyHOME OpenWebNet Bus Monitor`** appears in the UI card picker.
   - Retained the backward-compatible custom element alias `customElements.define("myhome-bus-card", class extends MyHomeBusCard {})` so existing dashboards configured with `type: custom:myhome-bus-card` continue to render without errors.

2. **Event Loop Non-Blocking Execution**:
   - In `custom_components/myhome/__init__.py`, `_get_card_url()` computed the SHA-256 content hash by reading the card JS file directly on the event loop, triggering Home Assistant's asyncio blocking call detector (`Detected blocking call to open with args ('.../myhome-bus-card.js', 'rb')`).
   - Wrapped `_get_card_url` and `get_ownd_version` invocations inside `await hass.async_add_executor_job(...)` to offload disk I/O to executor worker threads.
   - Enhanced Lovelace resource auto-registration to log registration status at `INFO` level for transparent diagnostics.

---

### Automated Tests
- Updated `tests/test_issue_275.py` to assert that `myhome-bus-card` is explicitly filtered out of `window.customCards` while preserving the custom element class definition.
- Verified test suite: **24/24 in test_init.py**, **4/4 in test_issue_275.py**, **984+ tests passing across the repository**.