### PR TITLE
Harden MH201 cover state, gateway availability, and version lookup

### DIFF
--- a/custom_components/myhome/alarm_control_panel.py
+++ b/custom_components/myhome/alarm_control_panel.py
@@ -221,6 +221,7 @@ class MyHOMEAlarmControlPanel(MyHOMEEntity, AlarmControlPanelEntity):
 
     async def async_added_to_hass(self):
         """Register dispatcher listener when added to hass."""
+        self._register_availability_listener()
         target_hass = self.hass or self._hass
         if target_hass is not None:
             unsub = async_dispatcher_connect(

--- a/custom_components/myhome/binary_sensor.py
+++ b/custom_components/myhome/binary_sensor.py
@@ -442,6 +442,7 @@ class MyHOMEDryContact(MyHOMEEntity, BinarySensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -543,6 +544,7 @@ class MyHOMEAuxiliary(MyHOMEEntity, BinarySensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -637,6 +639,7 @@ class MyHOMEMotionSensor(MyHOMEEntity, BinarySensorEntity, RestoreEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):

--- a/custom_components/myhome/button.py
+++ b/custom_components/myhome/button.py
@@ -181,6 +181,7 @@ class DisableCommandButtonEntity(ButtonEntity, MyHOMEEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -252,6 +253,7 @@ class EnableCommandButtonEntity(ButtonEntity, MyHOMEEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):

--- a/custom_components/myhome/climate.py
+++ b/custom_components/myhome/climate.py
@@ -448,6 +448,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity, RestoreEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
+        self._register_availability_listener()
         try:
             state = await self.async_get_last_state()
             if state is not None and state.state is not None:

--- a/custom_components/myhome/const.py
+++ b/custom_components/myhome/const.py
@@ -1,5 +1,6 @@
 """Constants for the MyHome component."""
 import logging
+from functools import lru_cache
 
 LOGGER = logging.getLogger(__package__)
 DOMAIN = "myhome"
@@ -10,6 +11,7 @@ INTEGRATION_VERSION = "2.0.0b8"
 REQUIRED_OWND_VERSION = "2.0.0b5"
 
 
+@lru_cache(maxsize=1)
 def get_ownd_version() -> str:
     """Return the installed version of the OWNd protocol engine."""
     try:

--- a/custom_components/myhome/cover.py
+++ b/custom_components/myhome/cover.py
@@ -382,6 +382,10 @@ class MyHOMECover(MyHOMEEntity, CoverEntity, RestoreEntity):
                         self._start_position = 100
                         self._attr_is_closed = False
 
+        # Subscribe before requesting the current status so the reply cannot
+        # arrive before this entity is ready to handle it.
+        await super().async_added_to_hass()
+
     async def async_will_remove_from_hass(self):
         """Run when entity will be removed from hass."""
         self._cancel_stop_task()
@@ -432,9 +436,16 @@ class MyHOMECover(MyHOMEEntity, CoverEntity, RestoreEntity):
             return
         target_position = kwargs[ATTR_POSITION]
         if self._advanced:
-            await self._gateway_handler.send(
-                OWNAutomationCommand.set_shutter_level(self._full_where, target_position)
-            )
+            if target_position <= 0:
+                await self._gateway_handler.send(
+                    OWNAutomationCommand.lower_shutter(self._full_where)
+                )
+            else:
+                await self._gateway_handler.send(
+                    OWNAutomationCommand.set_shutter_level(
+                        self._full_where, target_position
+                    )
+                )
             return
 
         self._cancel_stop_task()
@@ -548,4 +559,3 @@ class MyHOMECover(MyHOMEEntity, CoverEntity, RestoreEntity):
                 self.async_schedule_update_ha_state()
             except RuntimeError:
                 pass
-

--- a/custom_components/myhome/gateway.py
+++ b/custom_components/myhome/gateway.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_call_later
 from OWNd.connection import OWNCommandSession, OWNEventSession, OWNGateway, OWNSession
 from OWNd.message import (
     OWNAlarmEvent,
@@ -56,6 +57,7 @@ from .const import (
 
 EVENT_READY_TIMEOUT = 120
 COMMAND_SESSION_IDLE_TIMEOUT = 15.0
+AVAILABILITY_GRACE = 60
 
 
 class MyHOMEGatewayHandler:
@@ -84,6 +86,8 @@ class MyHOMEGatewayHandler:
         self._terminate_listener = False
         self._terminate_sender = False
         self.is_connected = False
+        self._available = False
+        self._unavailable_timer = None
         self._event_session_ready = asyncio.Event()
         self._sender_stop = asyncio.Event()
         self.listening_worker: asyncio.tasks.Task = None
@@ -166,17 +170,68 @@ class MyHOMEGatewayHandler:
     def profile(self):
         return self.gateway.profile
 
+    @property
+    def available(self) -> bool:
+        """Return the grace-filtered gateway availability."""
+        return self._available
+
+    @property
+    def availability_signal(self) -> str:
+        """Return the dispatcher signal for availability changes."""
+        return f"{DOMAIN}_{self.mac}_availability"
+
     async def test(self) -> Dict:
         return await OWNSession(gateway=self.gateway, logger=LOGGER).test_connection()
 
     @callback
     def _on_event_connection_state_change(self, connected: bool) -> None:
-        """Gate command sessions on the real event-session state."""
+        """Gate commands and publish sustained event-session availability."""
         self.is_connected = connected
         if connected:
             self._event_session_ready.set()
-        else:
-            self._event_session_ready.clear()
+            if self._unavailable_timer is not None:
+                self._unavailable_timer()
+                self._unavailable_timer = None
+            if not self._available:
+                self._available = True
+                LOGGER.info("%s Gateway available again.", self.log_id)
+                self._notify_availability()
+            return
+
+        self._event_session_ready.clear()
+        if self._terminate_listener:
+            return
+        if self._available and self._unavailable_timer is None:
+            LOGGER.warning(
+                "%s Gateway connection lost; marking unavailable in %ss "
+                "if not recovered.",
+                self.log_id,
+                AVAILABILITY_GRACE,
+            )
+            self._unavailable_timer = async_call_later(
+                self.hass,
+                AVAILABILITY_GRACE,
+                self._mark_unavailable,
+            )
+
+    @callback
+    def _mark_unavailable(self, _now) -> None:
+        """Mark the gateway unavailable after the reconnect grace period."""
+        self._unavailable_timer = None
+        if self.is_connected or not self._available:
+            return
+        self._available = False
+        LOGGER.warning(
+            "%s Gateway unavailable (outage exceeded %ss).",
+            self.log_id,
+            AVAILABILITY_GRACE,
+        )
+        self._notify_availability()
+
+    @callback
+    def _notify_availability(self) -> None:
+        """Notify all entities bound to this gateway."""
+        async_dispatcher_send(self.hass, self.availability_signal)
 
     async def listening_loop(self):
         self._terminate_listener = False
@@ -559,6 +614,11 @@ class MyHOMEGatewayHandler:
         LOGGER.info("%s Closing event listener", self.log_id)
         self._terminate_sender = True
         self._terminate_listener = True
+        if self._unavailable_timer is not None:
+            self._unavailable_timer()
+            self._unavailable_timer = None
+        self.is_connected = False
+        self._available = False
         self._event_session_ready.set()
         self._sender_stop.set()
 

--- a/custom_components/myhome/light.py
+++ b/custom_components/myhome/light.py
@@ -486,6 +486,7 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
+        self._register_availability_listener()
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,

--- a/custom_components/myhome/media_player.py
+++ b/custom_components/myhome/media_player.py
@@ -309,6 +309,7 @@ class MyHOMEMediaPlayer(MyHOMEEntity, MediaPlayerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register listeners when entity is added to Home Assistant."""
+        self._register_availability_listener()
         # Existing OWN event dispatcher connections
         self.async_on_remove(
             async_dispatcher_connect(

--- a/custom_components/myhome/myhome_device.py
+++ b/custom_components/myhome/myhome_device.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .gateway import MyHOMEGatewayHandler
 
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
@@ -35,6 +37,7 @@ class MyHOMEEntity(Entity):
         self._manufacturer = manufacturer or "BTicino S.p.A."
         self._model = model
         self._gateway_handler = gateway
+        self._availability_listener_registered = False
         self._attr_has_entity_name = False
         self._attr_name = name
         self.entity_id = f"{platform.lower()}.{name.lower().replace(' ', '_').replace('#', '')}"
@@ -58,8 +61,36 @@ class MyHOMEEntity(Entity):
         """Return gateway unique ID associated with this device."""
         return self._gateway_handler.unique_id
 
+    @property
+    def available(self) -> bool:
+        """Return whether the gateway is available."""
+        return self._gateway_handler.available
+
+    @callback
+    def _handle_availability_update(self) -> None:
+        """Write state when the gateway availability changes."""
+        self.async_write_ha_state()
+
+    @callback
+    def _register_availability_listener(self) -> None:
+        """Register the gateway availability listener once."""
+        if self._availability_listener_registered:
+            return
+        target_hass = self.hass or self._hass
+        if target_hass is None:
+            return
+        self.async_on_remove(
+            async_dispatcher_connect(
+                target_hass,
+                self._gateway_handler.availability_signal,
+                self._handle_availability_update,
+            )
+        )
+        self._availability_listener_registered = True
+
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         await self.async_update()
 
     async def async_will_remove_from_hass(self):

--- a/custom_components/myhome/sensor.py
+++ b/custom_components/myhome/sensor.py
@@ -527,6 +527,7 @@ class MyHOMEPowerSensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -633,6 +634,7 @@ class MyHOMEEnergySensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -760,6 +762,7 @@ class MyHOMETemperatureSensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -889,6 +892,7 @@ class MyHOMEIlluminanceSensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
+        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -956,4 +960,3 @@ class MyHOMEIlluminanceSensor(MyHOMEEntity, SensorEntity):
                     self.async_schedule_update_ha_state()
                 except Exception:
                     pass
-

--- a/custom_components/myhome/switch.py
+++ b/custom_components/myhome/switch.py
@@ -234,6 +234,7 @@ class MyHOMESwitch(MyHOMEEntity, SwitchEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
+        self._register_availability_listener()
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,

--- a/tests/test_component_alarm.py
+++ b/tests/test_component_alarm.py
@@ -158,13 +158,13 @@ class TestMyHOMEAlarmEntity:
     async def test_async_lifecycle_and_update(self, alarm_central, alarm_zone1):
         alarm_central.async_on_remove = MagicMock()
         await alarm_central.async_added_to_hass()
-        alarm_central.async_on_remove.assert_called_once()
+        assert alarm_central.async_on_remove.call_count == 2
         alarm_central._gateway_handler.send_status_request.assert_awaited()
 
         # Zone 1 also subscribes to global zone 0 broadcast
         alarm_zone1.async_on_remove = MagicMock()
         await alarm_zone1.async_added_to_hass()
-        assert alarm_zone1.async_on_remove.call_count == 2
+        assert alarm_zone1.async_on_remove.call_count == 3
 
     async def test_alarm_commands(self, alarm_central, alarm_zone1):
         # Disarm

--- a/tests/test_component_cover.py
+++ b/tests/test_component_cover.py
@@ -200,8 +200,12 @@ class TestMyHOMECoverEntity:
     async def test_async_lifecycle_and_update(self, basic_cover, hass):
         basic_cover.async_on_remove = MagicMock()
         await basic_cover.async_added_to_hass()
-        assert basic_cover.async_on_remove.call_count == 2
+        assert basic_cover.async_on_remove.call_count == 3
 
+        basic_cover._gateway_handler.send_status_request.assert_awaited_once()
+        assert str(basic_cover._gateway_handler.send_status_request.call_args[0][0]) == "*#2*21##"
+
+        basic_cover._gateway_handler.send_status_request.reset_mock()
         await basic_cover.async_update()
         basic_cover._gateway_handler.send_status_request.assert_awaited_once()
 
@@ -221,6 +225,28 @@ class TestMyHOMECoverEntity:
         advanced_cover._gateway_handler.send.reset_mock()
         await advanced_cover.async_set_cover_position(**{ATTR_POSITION: 45})
         advanced_cover._gateway_handler.send.assert_awaited()
+        assert (
+            str(advanced_cover._gateway_handler.send.call_args[0][0])
+            == "*#2*22#4#02*#11#001*45##"
+        )
+
+        # MH201 rejects the calibrated level command at 0%; use plain DOWN.
+        advanced_cover._gateway_handler.send.reset_mock()
+        await advanced_cover.async_set_cover_position(**{ATTR_POSITION: 0})
+        advanced_cover._gateway_handler.send.assert_awaited_once()
+        assert (
+            str(advanced_cover._gateway_handler.send.call_args[0][0])
+            == "*2*2*22#4#02##"
+        )
+
+        # 100% remains a calibrated level command because MH201 accepts it.
+        advanced_cover._gateway_handler.send.reset_mock()
+        await advanced_cover.async_set_cover_position(**{ATTR_POSITION: 100})
+        advanced_cover._gateway_handler.send.assert_awaited_once()
+        assert (
+            str(advanced_cover._gateway_handler.send.call_args[0][0])
+            == "*#2*22#4#02*#11#001*100##"
+        )
 
         # Set position without ATTR_POSITION kwarg
         advanced_cover._gateway_handler.send.reset_mock()
@@ -522,13 +548,19 @@ class TestMyHOMECoverEntity:
         await basic_cover.async_added_to_hass()
         assert basic_cover.current_cover_position == 50
 
-        # 3. Advanced cover does not call async_get_last_state (relies on hardware status)
+        # 3. Advanced cover does not restore stale state and requests live hardware status
         advanced_cover._attr_current_cover_position = 50
         advanced_cover.async_get_last_state = AsyncMock(
             return_value=State("cover.advanced_shutter", "open", {ATTR_CURRENT_POSITION: 80})
         )
+        advanced_cover._gateway_handler.send_status_request.reset_mock()
         await advanced_cover.async_added_to_hass()
         advanced_cover.async_get_last_state.assert_not_called()
+        advanced_cover._gateway_handler.send_status_request.assert_awaited_once()
+        assert (
+            str(advanced_cover._gateway_handler.send_status_request.call_args[0][0])
+            == "*#2*22#4#02*10##"
+        )
         assert advanced_cover._attr_current_cover_position == 50
 
 
@@ -766,7 +798,3 @@ async def test_cover_advanced_shutter_key_precedence(hass, mock_gateway):
 
     assert len(added) == 1
     assert added[0]._advanced is True
-
-
-
-

--- a/tests/test_component_light.py
+++ b/tests/test_component_light.py
@@ -980,7 +980,7 @@ async def test_light_async_added_to_hass_requests_initial_state(hass):
 
     with patch.object(light, "async_on_remove") as mock_on_remove:
         await light.async_added_to_hass()
-        mock_on_remove.assert_called_once()
+        assert mock_on_remove.call_count == 2
         mock_gateway.send_status_request.assert_called_once()
 
     # Verify dimmable light requests brightness status
@@ -1005,5 +1005,4 @@ async def test_light_async_added_to_hass_requests_initial_state(hass):
     with patch.object(dimmer, "async_on_remove"):
         await dimmer.async_added_to_hass()
         mock_gateway.send_status_request.assert_called_once()
-
 

--- a/tests/test_component_logic_more.py
+++ b/tests/test_component_logic_more.py
@@ -290,7 +290,7 @@ class TestSwitchEntity:
         with patch("custom_components.myhome.switch.async_dispatcher_connect"):
             await sw_interface.async_added_to_hass()
         # Connected to both full_where and base where
-        assert sw_interface.async_on_remove.call_count == 2
+        assert sw_interface.async_on_remove.call_count == 3
 
         # 4. Unload
         await async_unload_entry(mock_hass, config_entry)
@@ -521,7 +521,7 @@ class TestCoverEntity:
         cover.hass = mock_hass
         cover.async_on_remove = MagicMock()
         await cover.async_added_to_hass()
-        assert cover.async_on_remove.call_count == 2
+        assert cover.async_on_remove.call_count == 3
 
 
 # ── Button Entities ────────────────────────────────────────────────────────

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -95,6 +95,64 @@ def test_gateway_properties(gateway_handler, mock_config_entry):
         assert gateway_handler.mac == "00:11:22:33:44:55"
 
 
+def test_gateway_availability_requires_connection(gateway_handler):
+    """Availability changes only after a real event-session transition."""
+    assert gateway_handler.available is False
+
+    with patch("custom_components.myhome.gateway.async_dispatcher_send") as send:
+        gateway_handler._on_event_connection_state_change(True)
+
+    assert gateway_handler.available is True
+    assert gateway_handler.is_connected is True
+    send.assert_called_once_with(
+        gateway_handler.hass,
+        gateway_handler.availability_signal,
+    )
+
+
+def test_gateway_transient_disconnect_stays_available(gateway_handler):
+    """A recovery inside the grace period must not flap entity availability."""
+    cancel_timer = MagicMock()
+    gateway_handler._on_event_connection_state_change(True)
+
+    with (
+        patch(
+            "custom_components.myhome.gateway.async_call_later",
+            return_value=cancel_timer,
+        ) as call_later,
+        patch("custom_components.myhome.gateway.async_dispatcher_send") as send,
+    ):
+        gateway_handler._on_event_connection_state_change(False)
+        assert gateway_handler.available is True
+        call_later.assert_called_once()
+
+        gateway_handler._on_event_connection_state_change(True)
+
+    cancel_timer.assert_called_once()
+    assert gateway_handler.available is True
+    send.assert_not_called()
+
+
+def test_gateway_sustained_disconnect_marks_unavailable(gateway_handler):
+    """A disconnect lasting beyond the grace period marks entities unavailable."""
+    gateway_handler._on_event_connection_state_change(True)
+
+    with (
+        patch("custom_components.myhome.gateway.async_call_later") as call_later,
+        patch("custom_components.myhome.gateway.async_dispatcher_send") as send,
+    ):
+        gateway_handler._on_event_connection_state_change(False)
+        mark_unavailable = call_later.call_args.args[2]
+        mark_unavailable(None)
+
+    assert gateway_handler.available is False
+    assert gateway_handler.is_connected is False
+    send.assert_called_once_with(
+        gateway_handler.hass,
+        gateway_handler.availability_signal,
+    )
+
+
 @pytest.mark.asyncio
 async def test_gateway_test_connection(gateway_handler):
     with patch("custom_components.myhome.gateway.OWNSession") as mock_session_cls:
@@ -161,10 +219,18 @@ async def test_gateway_send_and_send_status_request(gateway_handler):
 @pytest.mark.asyncio
 async def test_gateway_close_listener(gateway_handler):
     gateway_handler.sending_workers = [MagicMock(), MagicMock()]
+    cancel_timer = MagicMock()
+    gateway_handler._unavailable_timer = cancel_timer
+    gateway_handler._available = True
+    gateway_handler.is_connected = True
     res = await gateway_handler.close_listener()
     assert res is True
     assert gateway_handler._terminate_sender is True
     assert gateway_handler._terminate_listener is True
+    assert gateway_handler.available is False
+    assert gateway_handler.is_connected is False
+    assert gateway_handler._unavailable_timer is None
+    cancel_timer.assert_called_once()
 
     # Queue full handling
     with patch.object(gateway_handler.send_buffer, "put_nowait", side_effect=asyncio.QueueFull):
@@ -979,7 +1045,6 @@ async def test_gateway_sending_loop_timeout_and_terminate_branches(gateway_handl
     term_task = asyncio.create_task(terminate_during_wait())
     await gateway_handler.sending_loop(1)
     await term_task
-
 
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -153,6 +153,18 @@ def test_gateway_sustained_disconnect_marks_unavailable(gateway_handler):
     )
 
 
+def test_gateway_stale_unavailable_callback_is_ignored(gateway_handler):
+    """A stale grace-period callback must not undo a successful reconnect."""
+    gateway_handler._on_event_connection_state_change(True)
+
+    with patch("custom_components.myhome.gateway.async_dispatcher_send") as send:
+        gateway_handler._mark_unavailable(None)
+
+    assert gateway_handler.available is True
+    assert gateway_handler.is_connected is True
+    send.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_gateway_test_connection(gateway_handler):
     with patch("custom_components.myhome.gateway.OWNSession") as mock_session_cls:
@@ -1045,7 +1057,6 @@ async def test_gateway_sending_loop_timeout_and_terminate_branches(gateway_handl
     term_task = asyncio.create_task(terminate_during_wait())
     await gateway_handler.sending_loop(1)
     await term_task
-
 
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1110,14 +1110,20 @@ def test_get_ownd_version():
     """Test get_ownd_version helper returns version or fallback."""
     from custom_components.myhome.const import get_ownd_version
 
-    # Success path
-    ver = get_ownd_version()
-    assert isinstance(ver, str)
-    assert ver != ""
+    get_ownd_version.cache_clear()
+
+    # Success path is cached so later event-loop callers do not touch disk.
+    with patch("importlib.metadata.version", return_value="2.0.0b5") as mock_version:
+        assert get_ownd_version() == "2.0.0b5"
+        assert get_ownd_version() == "2.0.0b5"
+        mock_version.assert_called_once_with("OWNd")
 
     # Exception fallback
+    get_ownd_version.cache_clear()
     with patch("importlib.metadata.version", side_effect=Exception("Package not found")):
         assert get_ownd_version() == "unknown"
+
+    get_ownd_version.cache_clear()
 
 
 async def test_async_ensure_ownd_engine_fast_path(hass: HomeAssistant):
@@ -1200,7 +1206,6 @@ async def test_async_setup_entry_engine_mismatch_raises_not_ready(hass: HomeAssi
     with patch("custom_components.myhome.async_ensure_ownd_engine", return_value=False):
         with pytest.raises(ConfigEntryNotReady):
             await async_setup_entry(hass, entry)
-
 
 
 

--- a/tests/test_legacy_platforms.py
+++ b/tests/test_legacy_platforms.py
@@ -24,6 +24,7 @@ from custom_components.myhome.const import (
     CONF_DEVICE_MODEL,
     CONF_DEVICE_TYPE,
     CONF_ENTITIES,
+    CONF_ENTITY,
     CONF_ENTITY_NAME,
     CONF_FAN_SUPPORT,
     CONF_FIRMWARE,
@@ -140,6 +141,8 @@ async def test_legacy_platforms_setup_and_execution(hass: HomeAssistant, mock_ga
 
     success = await hass.config_entries.async_setup(config_entry.entry_id)
     assert success
+    await hass.async_block_till_done()
+    hass.data[DOMAIN][mac_addr][CONF_ENTITY]._on_event_connection_state_change(True)
     await hass.async_block_till_done()
 
     # Hit Switch turn_on and turn_off coverage

--- a/tests/test_myhome_yaml_fallback.py
+++ b/tests/test_myhome_yaml_fallback.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.myhome.const import (
+    CONF_ENTITY,
     CONF_FILE_PATH,
     CONF_PLATFORMS,
     DOMAIN,
@@ -439,6 +440,8 @@ async def test_switch_yaml_fallback_deduplication_and_no_ghost_light(hass: HomeA
         with patch("custom_components.myhome.gateway.MyHOMEGatewayHandler.send", mock_send):
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()
+            hass.data[DOMAIN][mac][CONF_ENTITY]._on_event_connection_state_change(True)
+            await hass.async_block_till_done()
 
             # Verify ghost light and corrupted duplicate switch were purged
             assert ent_reg.async_get(ghost_light.entity_id) is None
@@ -557,4 +560,3 @@ switch:
         assert await hass.config_entries.async_unload(entry1.entry_id)
         assert await hass.config_entries.async_unload(entry2.entry_id)
         await hass.async_block_till_done()
-

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -100,6 +100,8 @@ class TestMyHOMEEntity:
     async def test_entity_lifecycle_hooks(self, mock_hass, mock_gateway):
         with patch("custom_components.myhome.myhome_device.Entity.__init__", return_value=None):
             from custom_components.myhome.myhome_device import MyHOMEEntity
+            mock_gateway.available = True
+            mock_gateway.availability_signal = "myhome_test_availability"
             entity = MyHOMEEntity(
                 hass=mock_hass,
                 name="Test Device",
@@ -112,8 +114,24 @@ class TestMyHOMEEntity:
                 gateway=mock_gateway,
             )
             entity.async_update = AsyncMock()
-            await entity.async_added_to_hass()
+            entity.async_on_remove = MagicMock()
+            entity.async_write_ha_state = MagicMock()
+            with patch(
+                "custom_components.myhome.myhome_device.async_dispatcher_connect",
+                return_value=MagicMock(),
+            ) as connect:
+                await entity.async_added_to_hass()
+                entity._register_availability_listener()
+
             entity.async_update.assert_awaited_once()
+            assert entity.available is True
+            connect.assert_called_once_with(
+                mock_hass,
+                mock_gateway.availability_signal,
+                entity._handle_availability_update,
+            )
+            entity._handle_availability_update()
+            entity.async_write_ha_state.assert_called_once()
             await entity.async_will_remove_from_hass()
 
     async def test_entity_via_device_id_annotation(self, mock_hass, mock_gateway):

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -134,6 +134,30 @@ class TestMyHOMEEntity:
             entity.async_write_ha_state.assert_called_once()
             await entity.async_will_remove_from_hass()
 
+    def test_availability_listener_waits_for_hass(self, mock_gateway):
+        """Do not subscribe before Home Assistant has been assigned to the entity."""
+        with patch("custom_components.myhome.myhome_device.Entity.__init__", return_value=None):
+            from custom_components.myhome.myhome_device import MyHOMEEntity
+            entity = MyHOMEEntity(
+                hass=None,
+                name="Test Device",
+                platform="light",
+                device_id="21",
+                who="1",
+                where="21",
+                manufacturer="BTicino",
+                model="Test",
+                gateway=mock_gateway,
+            )
+
+            with patch(
+                "custom_components.myhome.myhome_device.async_dispatcher_connect"
+            ) as connect:
+                entity._register_availability_listener()
+
+            connect.assert_not_called()
+            assert entity._availability_listener_registered is False
+
     async def test_entity_via_device_id_annotation(self, mock_hass, mock_gateway):
         from homeassistant.helpers.device_registry import DeviceInfo
         with patch.dict(DeviceInfo.__annotations__, {"via_device_id": str}):

--- a/tests/test_platforms_integration.py
+++ b/tests/test_platforms_integration.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from OWNd.message import OWNEvent
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.myhome.const import DOMAIN
+from custom_components.myhome.const import CONF_ENTITY, DOMAIN
 
 # List of platforms we want to ensure get loaded
 PLATFORMS = ["light", "climate", "cover", "sensor", "binary_sensor", "switch", "media_player"]
@@ -55,6 +55,10 @@ async def test_platforms_setup_and_unload(hass: HomeAssistant, mock_gateway_conn
     # or exist in the platforms list if defined statically.
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    hass.data[DOMAIN][config_entry.data["mac"]][
+        CONF_ENTITY
+    ]._on_event_connection_state_change(True)
+    await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -89,6 +93,10 @@ async def test_platform_dynamic_discovery(hass: HomeAssistant, mock_gateway_conn
     config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    hass.data[DOMAIN][config_entry.data["mac"]][
+        CONF_ENTITY
+    ]._on_event_connection_state_change(True)
     await hass.async_block_till_done()
 
     # Dispatch a WHO=1 (Light) event
@@ -130,4 +138,3 @@ async def test_platform_dynamic_discovery(hass: HomeAssistant, mock_gateway_conn
     # Clean up entry
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-

--- a/tests/test_sensor_dispatcher.py
+++ b/tests/test_sensor_dispatcher.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from OWNd.message import OWNMessage
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.myhome.const import CONF_FILE_PATH, DOMAIN
+from custom_components.myhome.const import CONF_ENTITY, CONF_FILE_PATH, DOMAIN
 
 MAC = "00:03:50:00:12:34"
 
@@ -34,6 +34,8 @@ async def setup_gateway(hass, mac=MAC, options=None):
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    hass.data[DOMAIN][mac][CONF_ENTITY]._on_event_connection_state_change(True)
     await hass.async_block_till_done()
     return entry
 
@@ -102,6 +104,8 @@ async def test_discovered_entities_restore_names_and_disabled_defaults(hass):
     await hass.async_block_till_done()
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
+    hass.data[DOMAIN][MAC][CONF_ENTITY]._on_event_connection_state_change(True)
+    await hass.async_block_till_done()
     after = {item.unique_id: item for item in sensor_entries(hass, entry)}
     assert before.keys() == after.keys()
     assert after[power.unique_id].entity_id == "sensor.kitchen_power"
@@ -164,4 +168,3 @@ async def test_yaml_sensors_update_without_alias_duplicates(hass, tmp_path):
     assert len(sensor_entries(hass, entry)) == 9
     assert f"{MAC}-18-52-power" not in entities
     assert entities[f"{MAC}-18-51-power"].original_name == "House Power"
-


### PR DESCRIPTION
## Summary

This PR collects the MH201 reliability fixes that have now been exercised on real hardware against the current `v2-phase1-architecture` branch and `OWNd==2.0.0b5`.

No OWNd runtime changes are included; the manifest remains pinned to `OWNd==2.0.0b5`.

## Changes

### Cover startup state

`MyHOMECover` now completes the base entity setup after restoring its previous state. This registers the dispatcher subscription before the current-position request is sent.

On the MH201, the status reply can arrive immediately. Previously that reply could arrive before the entity was subscribed, leaving some stationary covers at the restored/default 50% until they were moved. After this change, their real 0–100% position is received during startup.

### Advanced cover 0% handling

For advanced covers, only a target of 0% is mapped to the normal DOWN command. Targets from 1% through 100% still use the calibrated position command.

This is intentional MH201 behaviour observed on the bus: calibrated intermediate positions and 100% work correctly, while the dimension-11 0% command (`*#2*WHERE*#11#001*0##`) can be rejected or fail after retries. In practice, moving the slider to 0% could leave the cover moving in the wrong direction or not close it at all. The simple DOWN command closes reliably while preserving calibrated positioning for every non-zero target.

### Gateway and entity availability

- Gateway availability starts as false and becomes true only after a real event session is established.
- A lost event session clears the command-session gate immediately.
- A 60-second grace period avoids marking all entities unavailable during short reconnects.
- A sustained outage marks the gateway and all associated entities unavailable through a dispatcher signal.
- Reconnecting within the grace period cancels the timer; reconnecting after an outage restores availability automatically.
- Pending timers are cancelled during unload.
- Availability listeners are registered idempotently for every entity platform, including platforms that override `async_added_to_hass`.

### OWNd version metadata lookup

`get_ownd_version()` is now cached. Its first lookup is already run in Home Assistant's executor, while later calls from startup logging, diagnostics and the bus monitor use the cached value.

This removes the `homeassistant.util.loop` warnings for blocking `listdir`, `read_text` and `open` calls caused by repeated `importlib.metadata.version()` lookups in the event loop. The existing cache invalidation used by the OWNd self-healing path remains intact.

## Validation

Automated:

- Ruff: clean
- Full test suite: 987 passed
- Snapshot tests: 5 passed
- Tested with external `OWNd==2.0.0b5`

Real hardware (MH201):

- Correct cover positions immediately after Home Assistant startup, including covers that previously stayed at 50%
- Advanced 0%, intermediate and 100% positioning tested from both directions
- First light and cover commands after more than 15 seconds of command-session inactivity succeeded
- Network blackhole test: event-session loss detected, entities marked unavailable after the 60-second grace period, and automatic reconnection restored operation after the route was removed
- Home Assistant restarted without the previous blocking-I/O warnings

The existing event-before-command startup serialization is unchanged.