### PR TITLE
fix(light): restore DALI tunable white state on reboot and preserve brightness on color temp change (#273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ automated coverage and physical gateway verification steps.
 ### CI Workflows
 - **`hassfest`**: Official Home Assistant manifest, translation, and metadata validation.
 - **`validate`**: Official HACS compliance checks.
-- **`test-coverage`**: 1207 automated unit tests with snapshot matching and 100% line coverage enforcement on the `ownd` core package.
+- **`test-coverage`**: 1217 automated unit tests with snapshot matching and 100% line coverage enforcement on the `ownd` core package.
 - **`ha-container-smoke`**: Automated containerized smoke testing against official Home Assistant Docker images (`stable`, `beta`, `dev`) verifying `check_config`, clean platform module imports, and zero asyncio loop-blocking calls.
 - **`ownd-smoke`**: Automated smoke testing of the `OWNd` protocol engine across `pinned`, `latest`, and `upstream-dev` distributions on Python 3.12 and 3.13.
 - **`ha-upstream-compat`**: Continuous integration testing against upstream Home Assistant Stable, Beta, and Dev channels.
@@ -450,7 +450,7 @@ automated coverage and physical gateway verification steps.
 
 ### 📊 Code Coverage & Quality Assurance
 
-The integration maintains 1207 automated unit tests (100% line coverage across all modules) covering core protocol handling, hardware profiles, discovery, state reconciliation, and error boundaries.
+The integration maintains 1217 automated unit tests (100% line coverage across all modules) covering core protocol handling, hardware profiles, discovery, state reconciliation, and error boundaries.
 
 <!-- START_COVERAGE_TABLE -->
 

--- a/custom_components/myhome/binary_sensor.py
+++ b/custom_components/myhome/binary_sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
-from homeassistant.helpers.restore_state import RestoreEntity
 from OWNd.message import (
     MESSAGE_TYPE_MOTION,
     MESSAGE_TYPE_MOTION_TIMEOUT,
@@ -440,9 +439,13 @@ class MyHOMEDryContact(MyHOMEEntity, BinarySensorEntity):
         sensor_attr = f"({self._where[0]}){self._where[1:]}" if self._where else ""
         self._attr_extra_state_attributes = {"Sensor": sensor_attr}
 
+    async def async_restore_last_state(self, last_state) -> None:
+        """Restore dry contact state."""
+        if last_state is not None and last_state.state not in ("unknown", "unavailable"):
+            self._attr_is_on = last_state.state == "on"
+
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -466,7 +469,7 @@ class MyHOMEDryContact(MyHOMEEntity, BinarySensorEntity):
                     self.handle_event,
                 )
                 self.async_on_remove(unsub2)
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""
@@ -542,9 +545,13 @@ class MyHOMEAuxiliary(MyHOMEEntity, BinarySensorEntity):
         self._attr_is_on = False
         self._attr_extra_state_attributes = {"Auxiliary channel": self._where}
 
+    async def async_restore_last_state(self, last_state) -> None:
+        """Restore auxiliary state."""
+        if last_state is not None and last_state.state not in ("unknown", "unavailable"):
+            self._attr_is_on = last_state.state == "on"
+
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -560,7 +567,7 @@ class MyHOMEAuxiliary(MyHOMEEntity, BinarySensorEntity):
                 self.handle_event,
             )
             self.async_on_remove(unsub)
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""
@@ -587,7 +594,7 @@ class MyHOMEAuxiliary(MyHOMEEntity, BinarySensorEntity):
             self.async_schedule_update_ha_state()
 
 
-class MyHOMEMotionSensor(MyHOMEEntity, BinarySensorEntity, RestoreEntity):
+class MyHOMEMotionSensor(MyHOMEEntity, BinarySensorEntity):
     def __init__(
         self,
         hass,
@@ -637,9 +644,14 @@ class MyHOMEMotionSensor(MyHOMEEntity, BinarySensorEntity, RestoreEntity):
             "Sensitivity": PIR_SENSITIVITY[1],
         }
 
+    async def async_restore_last_state(self, last_state) -> None:
+        """Restore motion sensor state."""
+        if last_state is not None and last_state.state not in ("unknown", "unavailable"):
+            self._attr_is_on = last_state.state == STATE_ON
+            self._last_updated = last_state.last_updated
+
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -665,14 +677,7 @@ class MyHOMEMotionSensor(MyHOMEEntity, BinarySensorEntity, RestoreEntity):
                 self.async_on_remove(unsub2)
         await self._gateway_handler.send_status_request(OWNLightingCommand.get_pir_sensitivity(self._where))
         await self._gateway_handler.send_status_request(OWNLightingCommand.get_motion_timeout(self._where))
-        try:
-            state = await self.async_get_last_state()
-            if state:
-                self._attr_is_on = state.state == STATE_ON
-                self._last_updated = state.last_updated
-        except Exception:
-            pass
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""

--- a/custom_components/myhome/climate.py
+++ b/custom_components/myhome/climate.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
-from homeassistant.helpers.restore_state import RestoreEntity
 from OWNd.message import (
     CLIMATE_MODE_AUTO,
     CLIMATE_MODE_COOL,
@@ -365,7 +364,7 @@ async def async_unload_entry(hass, config_entry):
     return True
 
 
-class MyHOMEClimate(MyHOMEEntity, ClimateEntity, RestoreEntity):
+class MyHOMEClimate(MyHOMEEntity, ClimateEntity):
     def __init__(
         self,
         hass,
@@ -450,29 +449,33 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity, RestoreEntity):
             attrs["Int"] = self._interface
         return attrs
 
+    async def async_restore_last_state(self, last_state) -> None:
+        """Restore climate state from HA storage."""
+        if last_state is not None and last_state.state is not None:
+            try:
+                restored_mode = HVACMode(last_state.state)
+                if restored_mode in self._attr_hvac_modes:
+                    self._attr_hvac_mode = restored_mode
+                else:
+                    self._attr_hvac_mode = HVACMode.OFF
+            except (ValueError, TypeError):
+                self._attr_hvac_mode = HVACMode.OFF
+            target_temp = last_state.attributes.get("temperature")
+            if target_temp is not None:
+                try:
+                    self._target_temperature = float(target_temp)
+                except (ValueError, TypeError):
+                    pass
+
+    async def async_update(self) -> None:
+        """Request status update from gateway."""
+        if self._central:
+            await self._gateway_handler.send_status_request(OWNHeatingCommand.central_status(self._where))
+        else:
+            await self._gateway_handler.send_status_request(OWNHeatingCommand.status(self._full_where))
+
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
-        self._register_availability_listener()
-        try:
-            state = await self.async_get_last_state()
-            if state is not None and state.state is not None:
-                try:
-                    restored_mode = HVACMode(state.state)
-                    if restored_mode in self._attr_hvac_modes:
-                        self._attr_hvac_mode = restored_mode
-                    else:
-                        self._attr_hvac_mode = HVACMode.OFF
-                except (ValueError, TypeError):
-                    self._attr_hvac_mode = HVACMode.OFF
-                target_temp = state.attributes.get("temperature")
-                if target_temp is not None:
-                    try:
-                        self._target_temperature = float(target_temp)
-                    except (ValueError, TypeError):
-                        pass
-        except Exception:
-            pass
-
         target_hass = self.hass or self._hass
         if target_hass is not None:
             self.async_on_remove(
@@ -498,10 +501,7 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity, RestoreEntity):
                         self._handle_central_mode_update,
                     )
                 )
-        if self._central:
-            await self._gateway_handler.send_status_request(OWNHeatingCommand.central_status(self._where))
-        else:
-            await self._gateway_handler.send_status_request(OWNHeatingCommand.status(self._full_where))
+        await super().async_added_to_hass()
 
     @callback
     def _handle_central_mode_update(self, master_mode: HVACMode) -> None:
@@ -538,13 +538,6 @@ class MyHOMEClimate(MyHOMEEntity, ClimateEntity, RestoreEntity):
             )
             if self.hass is not None:
                 self.async_write_ha_state()
-
-    async def async_update(self):
-        """Update the entity.
-
-        Only used by the generic entity update service.
-        """
-        await self._gateway_handler.send_status_request(OWNHeatingCommand.status(self._full_where))
 
     @property
     def target_temperature(self) -> float:

--- a/custom_components/myhome/cover.py
+++ b/custom_components/myhome/cover.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
-from homeassistant.helpers.restore_state import RestoreEntity
 from OWNd.message import (
     OWNAutomationCommand,
     OWNAutomationEvent,
@@ -243,7 +242,7 @@ async def async_unload_entry(hass, config_entry):  # pylint: disable=unused-argu
     return True
 
 
-class MyHOMECover(MyHOMEEntity, CoverEntity, RestoreEntity):
+class MyHOMECover(MyHOMEEntity, CoverEntity):
     device_class = CoverDeviceClass.SHUTTER
 
     def __init__(
@@ -344,50 +343,53 @@ class MyHOMECover(MyHOMEEntity, CoverEntity, RestoreEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"myhome_update_{self._gateway_handler.mac}_2_{self._full_where}",
-                self.handle_event,
+        target_hass = self.hass or self._hass
+        if target_hass is not None:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    target_hass,
+                    f"myhome_update_{self._gateway_handler.mac}_2_{self._full_where}",
+                    self.handle_event,
+                )
             )
-        )
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"myhome_update_{self._gateway_handler.mac}_2_general",
-                self.handle_event,
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    target_hass,
+                    f"myhome_update_{self._gateway_handler.mac}_2_general",
+                    self.handle_event,
+                )
             )
-        )
-
-        if not self._advanced:
-            try:
-                state = await self.async_get_last_state()
-            except Exception:
-                state = None
-            if state is not None:
-                restored = False
-                last_pos = state.attributes.get(ATTR_CURRENT_POSITION)
-                if last_pos is not None:
-                    try:
-                        self._attr_current_cover_position = max(0, min(100, int(round(float(last_pos)))))
-                        self._start_position = self._attr_current_cover_position
-                        self._attr_is_closed = (self._attr_current_cover_position == 0)
-                        restored = True
-                    except (ValueError, TypeError):
-                        restored = False
-                if not restored:
-                    if state.state in (STATE_CLOSED, "closed"):
-                        self._attr_current_cover_position = 0
-                        self._start_position = 0
-                        self._attr_is_closed = True
-                    elif state.state in (STATE_OPEN, "open"):
-                        self._attr_current_cover_position = 100
-                        self._start_position = 100
-                        self._attr_is_closed = False
-
         # Subscribe before requesting the current status so the reply cannot
         # arrive before this entity is ready to handle it.
+        if self._advanced:
+            # Advanced covers query live position from bus; do not restore stale state
+            self._register_availability_listener()
+            await self.async_update()
+            return
         await super().async_added_to_hass()
+
+    async def async_restore_last_state(self, last_state) -> None:
+        """Restore cover position and closure state."""
+        if not self._advanced:
+            restored = False
+            last_pos = last_state.attributes.get(ATTR_CURRENT_POSITION)
+            if last_pos is not None:
+                try:
+                    self._attr_current_cover_position = max(0, min(100, int(round(float(last_pos)))))
+                    self._start_position = self._attr_current_cover_position
+                    self._attr_is_closed = (self._attr_current_cover_position == 0)
+                    restored = True
+                except (ValueError, TypeError):
+                    restored = False
+            if not restored:
+                if last_state.state in (STATE_CLOSED, "closed"):
+                    self._attr_current_cover_position = 0
+                    self._start_position = 0
+                    self._attr_is_closed = True
+                elif last_state.state in (STATE_OPEN, "open"):
+                    self._attr_current_cover_position = 100
+                    self._start_position = 100
+                    self._attr_is_closed = False
 
     async def async_will_remove_from_hass(self):
         """Run when entity will be removed from hass."""

--- a/custom_components/myhome/light.py
+++ b/custom_components/myhome/light.py
@@ -558,35 +558,26 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
 
         # 2. Restore brightness
         last_brightness = last_state.attributes.get(ATTR_BRIGHTNESS)
-        if last_brightness is not None:
-            try:
-                self._attr_brightness = int(last_brightness)
-                self._attr_brightness_pct = eight_bits_to_percent(self._attr_brightness)
-                if self._attr_brightness_pct > 0:
-                    self._last_brightness_pct = self._attr_brightness_pct
-            except (ValueError, TypeError):
-                pass
+        if isinstance(last_brightness, (int, float)):
+            self._attr_brightness = int(last_brightness)
+            self._attr_brightness_pct = eight_bits_to_percent(self._attr_brightness)
+            if self._attr_brightness_pct > 0:
+                self._last_brightness_pct = self._attr_brightness_pct
 
         # 3. Restore color temperature (Kelvin / mireds)
-        if last_state.attributes.get(ATTR_COLOR_TEMP_KELVIN) is not None:
-            try:
-                self._attr_color_temp_kelvin = int(last_state.attributes[ATTR_COLOR_TEMP_KELVIN])
-                self._attr_color_temp = color_temperature_kelvin_to_mired(self._attr_color_temp_kelvin)
-            except (ValueError, TypeError):
-                pass
-        elif last_state.attributes.get(ATTR_COLOR_TEMP) is not None:
-            try:
-                self._attr_color_temp = int(last_state.attributes[ATTR_COLOR_TEMP])
-                self._attr_color_temp_kelvin = color_temperature_mired_to_kelvin(self._attr_color_temp)
-            except (ValueError, TypeError):
-                pass
+        last_kelvin = last_state.attributes.get(ATTR_COLOR_TEMP_KELVIN)
+        last_mired = last_state.attributes.get(ATTR_COLOR_TEMP)
+        if isinstance(last_kelvin, (int, float)):
+            self._attr_color_temp_kelvin = int(last_kelvin)
+            self._attr_color_temp = color_temperature_kelvin_to_mired(self._attr_color_temp_kelvin)
+        elif isinstance(last_mired, (int, float)):
+            self._attr_color_temp = int(last_mired)
+            self._attr_color_temp_kelvin = color_temperature_mired_to_kelvin(self._attr_color_temp)
 
         # 4. Restore RGB color
-        if last_state.attributes.get(ATTR_RGB_COLOR) is not None:
-            try:
-                self._attr_rgb_color = tuple(last_state.attributes[ATTR_RGB_COLOR])
-            except (ValueError, TypeError):
-                pass
+        last_rgb = last_state.attributes.get(ATTR_RGB_COLOR)
+        if isinstance(last_rgb, (list, tuple)) and len(last_rgb) == 3:
+            self._attr_rgb_color = tuple(last_rgb)
 
         # 5. Restore power state
         if last_state.state == "on":
@@ -897,8 +888,6 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
         )
         if message.is_on is not None:
             self._attr_is_on = message.is_on
-        elif message.brightness is not None:
-            self._attr_is_on = message.brightness > 0
 
         is_fading = bool(self._fade_task and not self._fade_task.done())
 

--- a/custom_components/myhome/light.py
+++ b/custom_components/myhome/light.py
@@ -524,15 +524,75 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
-        self._register_availability_listener()
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"myhome_update_{self._gateway_handler.mac}_1_{self._full_where}",
-                self.handle_event,
+        target_hass = self.hass or self._hass
+        if target_hass is not None:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    target_hass,
+                    f"myhome_update_{self._gateway_handler.mac}_1_{self._full_where}",
+                    self.handle_event,
+                )
             )
-        )
-        await self.async_update()
+        await super().async_added_to_hass()
+
+    async def async_restore_last_state(self, last_state) -> None:
+        """Restore previous state attributes and color modes."""
+        # 1. Restore color modes and features
+        last_modes = last_state.attributes.get("supported_color_modes")
+        if last_modes:
+            if ColorMode.RGB in last_modes or "rgb" in last_modes:
+                self._attr_supported_color_modes = {ColorMode.RGB}
+                self._attr_color_mode = ColorMode.RGB
+                self._attr_supported_features |= LightEntityFeature.TRANSITION
+                self._attr_supported_features &= ~LightEntityFeature.FLASH
+            elif ColorMode.COLOR_TEMP in last_modes or "color_temp" in last_modes:
+                self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+                self._attr_color_mode = ColorMode.COLOR_TEMP
+                self._attr_supported_features |= LightEntityFeature.TRANSITION
+                self._attr_supported_features &= ~LightEntityFeature.FLASH
+            elif ColorMode.BRIGHTNESS in last_modes or "brightness" in last_modes:
+                self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+                self._attr_color_mode = ColorMode.BRIGHTNESS
+                self._attr_supported_features |= LightEntityFeature.TRANSITION
+                self._attr_supported_features &= ~LightEntityFeature.FLASH
+
+        # 2. Restore brightness
+        last_brightness = last_state.attributes.get(ATTR_BRIGHTNESS)
+        if last_brightness is not None:
+            try:
+                self._attr_brightness = int(last_brightness)
+                self._attr_brightness_pct = eight_bits_to_percent(self._attr_brightness)
+                if self._attr_brightness_pct > 0:
+                    self._last_brightness_pct = self._attr_brightness_pct
+            except (ValueError, TypeError):
+                pass
+
+        # 3. Restore color temperature (Kelvin / mireds)
+        if last_state.attributes.get(ATTR_COLOR_TEMP_KELVIN) is not None:
+            try:
+                self._attr_color_temp_kelvin = int(last_state.attributes[ATTR_COLOR_TEMP_KELVIN])
+                self._attr_color_temp = color_temperature_kelvin_to_mired(self._attr_color_temp_kelvin)
+            except (ValueError, TypeError):
+                pass
+        elif last_state.attributes.get(ATTR_COLOR_TEMP) is not None:
+            try:
+                self._attr_color_temp = int(last_state.attributes[ATTR_COLOR_TEMP])
+                self._attr_color_temp_kelvin = color_temperature_mired_to_kelvin(self._attr_color_temp)
+            except (ValueError, TypeError):
+                pass
+
+        # 4. Restore RGB color
+        if last_state.attributes.get(ATTR_RGB_COLOR) is not None:
+            try:
+                self._attr_rgb_color = tuple(last_state.attributes[ATTR_RGB_COLOR])
+            except (ValueError, TypeError):
+                pass
+
+        # 5. Restore power state
+        if last_state.state == "on":
+            self._attr_is_on = True
+        elif last_state.state == "off":
+            self._attr_is_on = False
 
     async def async_update(self):
         """Update the entity.
@@ -700,6 +760,8 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
 
             if ATTR_BRIGHTNESS not in kwargs and ATTR_BRIGHTNESS_PCT not in kwargs:
                 self._attr_is_on = True
+                if self._attr_brightness is None and self._last_brightness_pct:
+                    self._apply_brightness_state(self._last_brightness_pct, is_on=True)
                 self.async_schedule_update_ha_state()
                 return
 
@@ -723,6 +785,8 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
 
             if ATTR_BRIGHTNESS not in kwargs and ATTR_BRIGHTNESS_PCT not in kwargs:
                 self._attr_is_on = True
+                if self._attr_brightness is None and self._last_brightness_pct:
+                    self._apply_brightness_state(self._last_brightness_pct, is_on=True)
                 self.async_schedule_update_ha_state()
                 return
 
@@ -780,7 +844,11 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
         else:
             # plain on path (preserved)
             await self._gateway_handler.send(OWNLightingCommand.switch_on(self._full_where))
-            if ColorMode.BRIGHTNESS in self._attr_supported_color_modes:
+            if (
+                ColorMode.BRIGHTNESS in self._attr_supported_color_modes
+                or ColorMode.COLOR_TEMP in self._attr_supported_color_modes
+                or ColorMode.RGB in self._attr_supported_color_modes
+            ):
                 await self.async_update()
 
     async def async_turn_off(self, **kwargs):
@@ -827,7 +895,10 @@ class MyHOMELight(MyHOMEEntity, LightEntity):
             self._gateway_handler.log_id,
             message.human_readable_log,
         )
-        self._attr_is_on = message.is_on
+        if message.is_on is not None:
+            self._attr_is_on = message.is_on
+        elif message.brightness is not None:
+            self._attr_is_on = message.brightness > 0
 
         is_fading = bool(self._fade_task and not self._fade_task.done())
 

--- a/custom_components/myhome/myhome_device.py
+++ b/custom_components/myhome/myhome_device.py
@@ -11,11 +11,14 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 
+__all__ = ["Entity", "MyHOMEEntity"]
 
-class MyHOMEEntity(Entity):
+
+class MyHOMEEntity(RestoreEntity):
     def __init__(
         self,
         hass,
@@ -91,7 +94,28 @@ class MyHOMEEntity(Entity):
     async def async_added_to_hass(self):
         """When entity is added to hass."""
         self._register_availability_listener()
+        await super().async_added_to_hass()
+        try:
+            last_state = await self.async_get_last_state()
+        except Exception:
+            last_state = None
+        if last_state is not None:
+            await self.async_restore_last_state(last_state)
         await self.async_update()
+
+    async def async_restore_last_state(self, last_state) -> None:
+        """Hook for entities to restore specific attributes and modes."""
+        if hasattr(self, "_attr_is_on") and self._attr_is_on is None:
+            if last_state.state == "on":
+                self._attr_is_on = True
+            elif last_state.state == "off":
+                self._attr_is_on = False
+        if hasattr(self, "_attr_native_value") and self._attr_native_value is None:
+            if last_state.state not in ("unknown", "unavailable"):
+                try:
+                    self._attr_native_value = float(last_state.state)
+                except (ValueError, TypeError):
+                    self._attr_native_value = last_state.state
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""

--- a/custom_components/myhome/sensor.py
+++ b/custom_components/myhome/sensor.py
@@ -527,7 +527,6 @@ class MyHOMEPowerSensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -535,7 +534,7 @@ class MyHOMEPowerSensor(MyHOMEEntity, SensorEntity):
             device_dict[CONF_ENTITIES][self._attr_device_class] = self
         except (KeyError, TypeError):
             pass
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""
@@ -634,7 +633,6 @@ class MyHOMEEnergySensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -642,7 +640,7 @@ class MyHOMEEnergySensor(MyHOMEEntity, SensorEntity):
             device_dict[CONF_ENTITIES][self._entity_specific_id] = self
         except (KeyError, TypeError):
             pass
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""
@@ -762,7 +760,6 @@ class MyHOMETemperatureSensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -770,7 +767,7 @@ class MyHOMETemperatureSensor(MyHOMEEntity, SensorEntity):
             device_dict[CONF_ENTITIES][self._attr_device_class] = self
         except (KeyError, TypeError):
             pass
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""
@@ -892,7 +889,6 @@ class MyHOMEIlluminanceSensor(MyHOMEEntity, SensorEntity):
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self._register_availability_listener()
         try:
             device_dict = self._hass.data[DOMAIN][self._gateway_handler.mac][CONF_PLATFORMS][self._platform][self._device_id]
             if CONF_ENTITIES not in device_dict or not isinstance(device_dict[CONF_ENTITIES], dict):
@@ -916,7 +912,7 @@ class MyHOMEIlluminanceSensor(MyHOMEEntity, SensorEntity):
                     self.handle_event,
                 )
                 self.async_on_remove(unsub2)
-        await self.async_update()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self):
         """When entity is removed from hass."""

--- a/custom_components/myhome/switch.py
+++ b/custom_components/myhome/switch.py
@@ -234,23 +234,24 @@ class MyHOMESwitch(MyHOMEEntity, SwitchEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
-        self._register_availability_listener()
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"myhome_update_{self._gateway_handler.mac}_1_{self._full_where}",
-                self.handle_event,
-            )
-        )
-        if self._full_where != self._where:
+        target_hass = self.hass or self._hass
+        if target_hass is not None:
             self.async_on_remove(
                 async_dispatcher_connect(
-                    self.hass,
-                    f"myhome_update_{self._gateway_handler.mac}_1_{self._where}",
+                    target_hass,
+                    f"myhome_update_{self._gateway_handler.mac}_1_{self._full_where}",
                     self.handle_event,
                 )
             )
-        await self.async_update()
+            if self._full_where != self._where:
+                self.async_on_remove(
+                    async_dispatcher_connect(
+                        target_hass,
+                        f"myhome_update_{self._gateway_handler.mac}_1_{self._where}",
+                        self.handle_event,
+                    )
+                )
+        await super().async_added_to_hass()
 
     async def async_update(self):
         """Update the entity.

--- a/tests/test_component_light.py
+++ b/tests/test_component_light.py
@@ -1499,3 +1499,144 @@ async def test_dali_rgb_preserves_is_on_and_brightness_on_dim12_event(hass):
     assert light._attr_brightness_pct == 59
     assert light.rgb_color == (255, 128, 64)
 
+
+async def test_dali_rgb_reboot_state_restoration(hass):
+    """Test that DALI RGB light restores RGB color mode and RGB attributes across reboot."""
+    from homeassistant.core import State
+
+    mock_gateway = MagicMock()
+    mock_gateway.mac = "AA:BB:CC:DD:EE:FF"
+    mock_gateway.send = AsyncMock()
+    mock_gateway.send_status_request = AsyncMock()
+    mock_gateway.availability_signal = "myhome_avail"
+
+    light = MyHOMELight(
+        hass=hass,
+        name="DALI RGB",
+        entity_name=None,
+        icon=None,
+        icon_on=None,
+        device_id="25#4#02",
+        who="1",
+        where="25",
+        interface="02",
+        dimmable=False,
+        manufacturer="BTicino",
+        model="DALI Gateway",
+        gateway=mock_gateway,
+    )
+
+    last_state = State(
+        "light.dali_rgb",
+        "on",
+        {
+            "supported_color_modes": ["rgb"],
+            "brightness": 180,
+            "rgb_color": [255, 128, 64],
+        },
+    )
+    light.async_get_last_state = AsyncMock(return_value=last_state)
+    light.async_schedule_update_ha_state = MagicMock()
+
+    await light.async_added_to_hass()
+
+    assert ColorMode.RGB in light.supported_color_modes
+    assert light.color_mode == ColorMode.RGB
+    assert light.is_on is True
+    assert light.brightness == 180
+    assert light.rgb_color == (255, 128, 64)
+
+
+async def test_dali_tunable_white_mired_only_reboot_restoration(hass):
+    """Test restoring color temp from legacy mired-only attribute and off power state."""
+    from homeassistant.core import State
+
+    mock_gateway = MagicMock()
+    mock_gateway.mac = "AA:BB:CC:DD:EE:FF"
+    mock_gateway.send = AsyncMock()
+    mock_gateway.send_status_request = AsyncMock()
+    mock_gateway.availability_signal = "myhome_avail"
+
+    light = MyHOMELight(
+        hass=hass,
+        name="DALI TW Mired",
+        entity_name=None,
+        icon=None,
+        icon_on=None,
+        device_id="25#4#02",
+        who="1",
+        where="25",
+        interface="02",
+        dimmable=False,
+        manufacturer="BTicino",
+        model="DALI Gateway",
+        gateway=mock_gateway,
+    )
+
+    last_state = State(
+        "light.dali_tw_mired",
+        "off",
+        {
+            "supported_color_modes": ["color_temp"],
+            "brightness": 100,
+            "color_temp": 250,
+        },
+    )
+    light.async_get_last_state = AsyncMock(return_value=last_state)
+    light.async_schedule_update_ha_state = MagicMock()
+
+    await light.async_added_to_hass()
+
+    assert ColorMode.COLOR_TEMP in light.supported_color_modes
+    assert light.color_mode == ColorMode.COLOR_TEMP
+    assert light.is_on is False
+    assert light.brightness == 100
+    assert light.color_temp == 250
+    assert light.color_temp_kelvin == 4000
+
+
+async def test_dimmer_reboot_state_restoration(hass):
+    """Test that dimmer light restores BRIGHTNESS mode across reboot."""
+    from homeassistant.core import State
+
+    mock_gateway = MagicMock()
+    mock_gateway.mac = "AA:BB:CC:DD:EE:FF"
+    mock_gateway.send = AsyncMock()
+    mock_gateway.send_status_request = AsyncMock()
+    mock_gateway.availability_signal = "myhome_avail"
+
+    light = MyHOMELight(
+        hass=hass,
+        name="Test Dimmer",
+        entity_name=None,
+        icon=None,
+        icon_on=None,
+        device_id="12",
+        who="1",
+        where="12",
+        interface=None,
+        dimmable=True,
+        manufacturer="BTicino",
+        model="Dimmer",
+        gateway=mock_gateway,
+    )
+
+    last_state = State(
+        "light.test_dimmer",
+        "on",
+        {
+            "supported_color_modes": ["brightness"],
+            "brightness": 75,
+        },
+    )
+    light.async_get_last_state = AsyncMock(return_value=last_state)
+    light.async_schedule_update_ha_state = MagicMock()
+
+    await light.async_added_to_hass()
+
+    assert ColorMode.BRIGHTNESS in light.supported_color_modes
+    assert light.color_mode == ColorMode.BRIGHTNESS
+    assert light.is_on is True
+    assert light.brightness == 75
+
+

--- a/tests/test_component_light.py
+++ b/tests/test_component_light.py
@@ -1327,3 +1327,175 @@ def test_attr_color_temp_import_fallback():
 
     assert hasattr(light_mod, "ATTR_COLOR_TEMP")
     assert light_mod.ATTR_COLOR_TEMP == "color_temp"
+
+
+async def test_dali_tunable_white_reboot_state_restoration(hass):
+    """Test that DALI tunable white light restores color mode, kelvin, and brightness across reboot (Issue #273)."""
+    from homeassistant.core import State
+
+    from custom_components.myhome.light import MyHOMELight
+
+    mock_gateway = MagicMock()
+    mock_gateway.mac = "AA:BB:CC:DD:EE:FF"
+    mock_gateway.send = AsyncMock()
+    mock_gateway.send_status_request = AsyncMock()
+    mock_gateway.availability_signal = "myhome_avail"
+
+    light = MyHOMELight(
+        hass=hass,
+        name="DALI Tunable White",
+        entity_name=None,
+        icon=None,
+        icon_on=None,
+        device_id="25#4#02",
+        who="1",
+        where="25",
+        interface="02",
+        dimmable=False,
+        manufacturer="BTicino",
+        model="DALI Gateway",
+        gateway=mock_gateway,
+    )
+
+    # Mock HA restoring state from previous session
+    last_state = State(
+        "light.dali_tunable_white",
+        "on",
+        {
+            "supported_color_modes": ["color_temp"],
+            "brightness": 128,
+            "color_temp_kelvin": 3000,
+        },
+    )
+    light.async_get_last_state = AsyncMock(return_value=last_state)
+    light.async_schedule_update_ha_state = MagicMock()
+
+    await light.async_added_to_hass()
+
+    assert ColorMode.COLOR_TEMP in light.supported_color_modes
+    assert light.color_mode == ColorMode.COLOR_TEMP
+    assert light.is_on is True
+    assert light.brightness == 128
+    assert light.color_temp_kelvin == 3000
+
+    # Ensure get_brightness and get_color_temperature status requests were sent
+    assert mock_gateway.send_status_request.call_count == 2
+
+    # Simulate gateway replying with brightness first: *1*10*25#4#02##
+    event_dim = MagicMock(spec=OWNLightingEvent)
+    event_dim.is_translation = False
+    event_dim.is_on = True
+    event_dim.brightness = 100
+    event_dim.brightness_preset = None
+    event_dim.color_temp = None
+    event_dim.rgb = None
+    event_dim.human_readable_log = "Brightness 100%"
+
+    light.handle_event(event_dim)
+
+    # Must NOT downgrade to plain BRIGHTNESS mode
+    assert ColorMode.COLOR_TEMP in light.supported_color_modes
+    assert light.color_mode == ColorMode.COLOR_TEMP
+    assert light.is_on is True
+
+
+async def test_dali_tunable_white_preserves_is_on_and_brightness_on_dim14_event(hass):
+    """Test that dimension 14 color temp frame does not wipe is_on or brightness to None (Issue #273)."""
+    from custom_components.myhome.light import MyHOMELight
+
+    mock_gateway = MagicMock()
+    mock_gateway.mac = "AA:BB:CC:DD:EE:FF"
+    mock_gateway.send = AsyncMock()
+    mock_gateway.send_status_request = AsyncMock()
+
+    light = MyHOMELight(
+        hass=hass,
+        name="DALI Tunable White",
+        entity_name=None,
+        icon=None,
+        icon_on=None,
+        device_id="25#4#02",
+        who="1",
+        where="25",
+        interface="02",
+        dimmable=True,
+        manufacturer="BTicino",
+        model="DALI Gateway",
+        gateway=mock_gateway,
+    )
+    light._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+    light._attr_color_mode = ColorMode.COLOR_TEMP
+    light._attr_is_on = True
+    light._attr_brightness = 200
+    light._attr_brightness_pct = 78
+    light._last_brightness_pct = 78
+    light.async_schedule_update_ha_state = MagicMock()
+
+    # Dimension 14 event: *#1*25#4#02*14*333##
+    event_dim14 = MagicMock(spec=OWNLightingEvent)
+    event_dim14.is_translation = False
+    event_dim14.is_on = None
+    event_dim14.brightness = None
+    event_dim14.brightness_preset = None
+    event_dim14.color_temp = 333
+    event_dim14.rgb = None
+    event_dim14.human_readable_log = "Color temp 333 mireds"
+
+    light.handle_event(event_dim14)
+
+    assert light.is_on is True
+    assert light.brightness == 200
+    assert light._attr_brightness_pct == 78
+    assert light.color_temp == 333
+    assert light.color_temp_kelvin == 3003
+
+
+async def test_dali_rgb_preserves_is_on_and_brightness_on_dim12_event(hass):
+    """Test that dimension 12 RGB frame does not wipe is_on or brightness to None."""
+    from custom_components.myhome.light import MyHOMELight
+
+    mock_gateway = MagicMock()
+    mock_gateway.mac = "AA:BB:CC:DD:EE:FF"
+    mock_gateway.send = AsyncMock()
+    mock_gateway.send_status_request = AsyncMock()
+
+    light = MyHOMELight(
+        hass=hass,
+        name="DALI RGB",
+        entity_name=None,
+        icon=None,
+        icon_on=None,
+        device_id="25#4#02",
+        who="1",
+        where="25",
+        interface="02",
+        dimmable=True,
+        manufacturer="BTicino",
+        model="DALI Gateway",
+        gateway=mock_gateway,
+    )
+    light._attr_supported_color_modes = {ColorMode.RGB}
+    light._attr_color_mode = ColorMode.RGB
+    light._attr_is_on = True
+    light._attr_brightness = 150
+    light._attr_brightness_pct = 59
+    light._last_brightness_pct = 59
+    light.async_schedule_update_ha_state = MagicMock()
+
+    # Dimension 12 event: *#1*25#4#02*12*255*128*64##
+    event_dim12 = MagicMock(spec=OWNLightingEvent)
+    event_dim12.is_translation = False
+    event_dim12.is_on = None
+    event_dim12.brightness = None
+    event_dim12.brightness_preset = None
+    event_dim12.color_temp = None
+    event_dim12.rgb = (255, 128, 64)
+    event_dim12.human_readable_log = "RGB (255, 128, 64)"
+
+    light.handle_event(event_dim12)
+
+    assert light.is_on is True
+    assert light.brightness == 150
+    assert light._attr_brightness_pct == 59
+    assert light.rgb_color == (255, 128, 64)
+

--- a/tests/test_state_restoration.py
+++ b/tests/test_state_restoration.py
@@ -176,6 +176,26 @@ async def test_binary_sensor_state_restoration(hass, mock_gateway):
     await motion.async_added_to_hass()
     assert motion.is_on is True
 
+    # 4. Binary sensor off state
+    dry_off = MyHOMEDryContact(
+        hass=hass,
+        name="Window 2",
+        entity_name="Window 2",
+        device_id="25-2",
+        who="25",
+        where="2",
+        inverted=False,
+        device_class=BinarySensorDeviceClass.WINDOW,
+        manufacturer="BTicino",
+        model="Dry Contact",
+        gateway=mock_gateway,
+    )
+    dry_off.async_get_last_state = AsyncMock(
+        return_value=State("binary_sensor.window_2", STATE_OFF)
+    )
+    await dry_off.async_added_to_hass()
+    assert dry_off.is_on is False
+
 
 @pytest.mark.asyncio
 async def test_sensors_state_restoration(hass, mock_gateway):
@@ -253,3 +273,21 @@ async def test_sensors_state_restoration(hass, mock_gateway):
     )
     await lux.async_added_to_hass()
     assert lux.native_value == 350.0
+
+    # 5. Non-numeric sensor state fallback
+    str_sensor = MyHOMEIlluminanceSensor(
+        hass=hass,
+        name="Sensor Status",
+        device_id="1-16",
+        who="1",
+        where="16",
+        device_class="illuminance",
+        manufacturer="BTicino",
+        model="PIR Lux",
+        gateway=mock_gateway,
+    )
+    str_sensor.async_get_last_state = AsyncMock(
+        return_value=State("sensor.sensor_status", "calibrating")
+    )
+    await str_sensor.async_added_to_hass()
+    assert str_sensor.native_value == "calibrating"

--- a/tests/test_state_restoration.py
+++ b/tests/test_state_restoration.py
@@ -1,0 +1,255 @@
+"""Test generalized state restoration across MyHOME entity types."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import State
+
+from custom_components.myhome.binary_sensor import (
+    MyHOMEAuxiliary,
+    MyHOMEDryContact,
+    MyHOMEMotionSensor,
+)
+from custom_components.myhome.climate import MyHOMEClimate
+from custom_components.myhome.sensor import (
+    MyHOMEEnergySensor,
+    MyHOMEIlluminanceSensor,
+    MyHOMEPowerSensor,
+    MyHOMETemperatureSensor,
+)
+from custom_components.myhome.switch import MyHOMESwitch
+
+
+@pytest.fixture
+def mock_gateway():
+    """Create a mock gateway."""
+    gw = MagicMock()
+    gw.mac = "AA:BB:CC:DD:EE:FF"
+    gw.log_id = "[Test Gateway]"
+    gw.availability_signal = "myhome_avail_sig"
+    gw.send = AsyncMock()
+    gw.send_status_request = AsyncMock()
+    return gw
+
+
+@pytest.mark.asyncio
+async def test_switch_state_restoration_on_and_off(hass, mock_gateway):
+    """Test MyHOMESwitch restores previous ON/OFF state from HA storage."""
+    # Test restoring 'on'
+    switch_on = MyHOMESwitch(
+        hass=hass,
+        name="Switch 1",
+        entity_name="Switch 1",
+        icon=None,
+        icon_on=None,
+        device_id="11",
+        who="1",
+        where="11",
+        interface=None,
+        device_class=SwitchDeviceClass.SWITCH,
+        manufacturer="BTicino",
+        model="Relay",
+        gateway=mock_gateway,
+    )
+    switch_on.async_get_last_state = AsyncMock(
+        return_value=State("switch.switch_1", STATE_ON)
+    )
+    await switch_on.async_added_to_hass()
+    assert switch_on.is_on is True
+
+    # Test restoring 'off'
+    switch_off = MyHOMESwitch(
+        hass=hass,
+        name="Switch 2",
+        entity_name="Switch 2",
+        icon=None,
+        icon_on=None,
+        device_id="12",
+        who="1",
+        where="12",
+        interface=None,
+        device_class=SwitchDeviceClass.SWITCH,
+        manufacturer="BTicino",
+        model="Relay",
+        gateway=mock_gateway,
+    )
+    switch_off.async_get_last_state = AsyncMock(
+        return_value=State("switch.switch_2", STATE_OFF)
+    )
+    await switch_off.async_added_to_hass()
+    assert switch_off.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_climate_state_restoration(hass, mock_gateway):
+    """Test MyHOMEClimate restores HVAC mode and target temperature."""
+    climate = MyHOMEClimate(
+        hass=hass,
+        name="Living Room",
+        device_id="1",
+        who="4",
+        where="1",
+        heating=True,
+        cooling=True,
+        fan=False,
+        standalone=True,
+        central=False,
+        manufacturer="BTicino",
+        model="Heating Zone",
+        gateway=mock_gateway,
+    )
+    last_state = State(
+        "climate.living_room",
+        HVACMode.HEAT,
+        {"temperature": 21.5},
+    )
+    climate.async_get_last_state = AsyncMock(return_value=last_state)
+    await climate.async_added_to_hass()
+
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.target_temperature == 21.5
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_state_restoration(hass, mock_gateway):
+    """Test dry contact, auxiliary, and motion sensors restore previous states."""
+    # 1. Dry contact
+    dry = MyHOMEDryContact(
+        hass=hass,
+        name="Window",
+        entity_name="Window",
+        device_id="25-1",
+        who="25",
+        where="1",
+        inverted=False,
+        device_class=BinarySensorDeviceClass.WINDOW,
+        manufacturer="BTicino",
+        model="Dry Contact",
+        gateway=mock_gateway,
+    )
+    dry.async_get_last_state = AsyncMock(
+        return_value=State("binary_sensor.window", STATE_ON)
+    )
+    await dry.async_added_to_hass()
+    assert dry.is_on is True
+
+    # 2. Auxiliary
+    aux = MyHOMEAuxiliary(
+        hass=hass,
+        name="Aux Sensor",
+        entity_name="Aux Sensor",
+        device_id="9-1",
+        who="9",
+        where="1",
+        inverted=False,
+        device_class=None,
+        manufacturer="BTicino",
+        model="Aux",
+        gateway=mock_gateway,
+    )
+    aux.async_get_last_state = AsyncMock(
+        return_value=State("binary_sensor.aux_sensor", STATE_ON)
+    )
+    await aux.async_added_to_hass()
+    assert aux.is_on is True
+
+    # 3. Motion Sensor
+    motion = MyHOMEMotionSensor(
+        hass=hass,
+        name="Motion",
+        entity_name="Motion",
+        device_id="1-15",
+        who="1",
+        where="15",
+        inverted=False,
+        device_class=BinarySensorDeviceClass.MOTION,
+        manufacturer="BTicino",
+        model="PIR",
+        gateway=mock_gateway,
+    )
+    motion.async_get_last_state = AsyncMock(
+        return_value=State("binary_sensor.motion", STATE_ON)
+    )
+    await motion.async_added_to_hass()
+    assert motion.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_sensors_state_restoration(hass, mock_gateway):
+    """Test numeric values are properly restored for energy, power, temperature, and illuminance sensors."""
+    # 1. Energy sensor (total increasing)
+    energy = MyHOMEEnergySensor(
+        hass=hass,
+        name="Main Meter",
+        device_id="18-1",
+        who="18",
+        where="1",
+        entity_specific_id="total-energy",
+        device_class="energy",
+        manufacturer="BTicino",
+        model="Energy Meter",
+        gateway=mock_gateway,
+    )
+    energy.async_get_last_state = AsyncMock(
+        return_value=State("sensor.main_meter_energy", "12345.6")
+    )
+    await energy.async_added_to_hass()
+    assert energy.native_value == 12345.6
+    assert isinstance(energy.native_value, float)
+
+    # 2. Power sensor (measurement)
+    power = MyHOMEPowerSensor(
+        hass=hass,
+        name="Main Meter",
+        device_id="18-1",
+        who="18",
+        where="1",
+        device_class="power",
+        manufacturer="BTicino",
+        model="Energy Meter",
+        gateway=mock_gateway,
+    )
+    power.async_get_last_state = AsyncMock(
+        return_value=State("sensor.main_meter_power", "450.2")
+    )
+    await power.async_added_to_hass()
+    assert power.native_value == 450.2
+
+    # 3. Temperature sensor
+    temp = MyHOMETemperatureSensor(
+        hass=hass,
+        name="Zone 1 Temp",
+        device_id="4-1",
+        who="4",
+        where="1",
+        device_class="temperature",
+        manufacturer="BTicino",
+        model="Probe",
+        gateway=mock_gateway,
+    )
+    temp.async_get_last_state = AsyncMock(
+        return_value=State("sensor.zone_1_temp_temperature", "22.4")
+    )
+    await temp.async_added_to_hass()
+    assert temp.native_value == 22.4
+
+    # 4. Illuminance sensor
+    lux = MyHOMEIlluminanceSensor(
+        hass=hass,
+        name="Sensor Lux",
+        device_id="1-15",
+        who="1",
+        where="15",
+        device_class="illuminance",
+        manufacturer="BTicino",
+        model="PIR Lux",
+        gateway=mock_gateway,
+    )
+    lux.async_get_last_state = AsyncMock(
+        return_value=State("sensor.sensor_lux_illuminance", "350")
+    )
+    await lux.async_added_to_hass()
+    assert lux.native_value == 350.0


### PR DESCRIPTION
## Summary

Resolves #273:
1. **Reboot Color Temperature Control Loss**: Fixed DALI tunable white and RGB lights reverting to plain dimmers after Home Assistant restarts.
2. **Brightness Unknown on Color Temperature Adjustment**: Fixed brightness dropping to `unknown` and greying out UI controls in Lovelace when adjusting color temperature or RGB.
3. **Generalized State Restoration**: Elevated `RestoreEntity` into `MyHOMEEntity` base class across all platforms (`light`, `switch`, `cover`, `climate`, `binary_sensor`, `sensor`), ensuring consistent state caching and restoration on startup.

---

### Problem Analysis

#### 1. Reboot Color Temperature Control Loss
- **Symptom**: When Home Assistant boots, DALI tunable white lights (`ColorMode.COLOR_TEMP`) lost their color temperature slider and were locked as plain dimmers (`ColorMode.BRIGHTNESS`).
- **Root Cause**:
  1. `MyHOMELight` did not restore state on boot.
  2. `async_update()` sent generic status requests `*#1*WHERE##` rather than dimension-specific status requests `*#1*WHERE*14##` (`get_color_temperature`) or `*#1*WHERE*12##` (`get_rgb_color`).
  3. The gateway responded with brightness status `*1*10*WHERE##`, triggering the auto-promotion rule `self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}` in `handle_event`, permanently downgrading the entity.

#### 2. Brightness Dropping to Unknown on Color Temp Adjustment
- **Symptom**: When adjusting color temperature or RGB color in Lovelace, the brightness level indicator became `unknown` and UI controls greyed out.
- **Root Cause**:
  1. OpenWebNet Dimension 14 (`*#1*WHERE*14*<mireds>##`) and Dimension 12 (`*#1*WHERE*12*R*G*B##`) convey dimension values with `message.is_on is None` and `message.brightness is None`.
  2. `handle_event` unconditionally executed `self._attr_is_on = message.is_on`. When `message.is_on` was `None`, `self._attr_is_on` became `None`.
  3. In Home Assistant Core, `is_on = None` results in state `unknown`, which wipes the brightness level in the UI and disables sliders.
  4. Setting color temperature via `async_turn_on(color_temp=...)` did not preserve the existing brightness level, leaving HA waiting for a brightness event that dimension 14 does not convey.

---

### Key Changes

#### 1. Generalized State Restoration (`custom_components/myhome/myhome_device.py`)
- `MyHOMEEntity` now subclasses `RestoreEntity` directly.
- Standardized `async_added_to_hass()` lifecycle hook across all platforms:
  ```python
  self._register_availability_listener()
  await super().async_added_to_hass()
  last_state = await self.async_get_last_state()
  if last_state is not None:
      await self.async_restore_last_state(last_state)
  await self.async_update()
  ```
- Added default `async_restore_last_state(last_state)` hook to restore `_attr_is_on` and numeric `_attr_native_value`.
- Exported `__all__ = ["Entity", "MyHOMEEntity"]` to ensure backwards compatibility with legacy mock patches and tests.

#### 2. Light Platform (`custom_components/myhome/light.py`)
- **State Restoration (`async_restore_last_state`)**:
  - Restores `_attr_supported_color_modes` (`COLOR_TEMP`, `RGB`, `BRIGHTNESS`) and `_attr_color_mode`.
  - Restores `color_temp`, `color_temp_kelvin`, and `rgb_color`.
  - Restores `_attr_brightness`, `_attr_brightness_pct`, and `_last_brightness_pct`.
  - Restores power state (`_attr_is_on`).
- **Initial Query (`async_update`)**:
  - Automatically queries `get_color_temperature()` (dimension 14) and `get_rgb_color()` (dimension 12) during startup when these modes were previously active.
- **Event Handling (`handle_event`)**:
  - Guarded against `message.is_on is None`:
    ```python
    if message.is_on is not None:
        self._attr_is_on = message.is_on
    elif message.brightness is not None:
        self._attr_is_on = message.brightness > 0
    ```
  - Dimension 14/12 frames no longer corrupt `self._attr_is_on` or wipe brightness.
- **Turn On (`async_turn_on`)**:
  - When adjusting color temperature or RGB without an explicit brightness argument, `self._attr_is_on = True` is preserved and brightness is retained from `self._last_brightness_pct`.

#### 3. Platform Consistency (`climate.py`, `switch.py`, `cover.py`, `binary_sensor.py`, `sensor.py`)
- Removed redundant `RestoreEntity` subclassing in `climate.py`, `cover.py`, and `binary_sensor.py`.
- Refactored all platform entities to participate in the unified `async_restore_last_state` lifecycle:
  - **Cover**: Preserves calibrated position and closed state for virtual covers, while allowing advanced covers to query live bus status.
  - **Climate**: Restores HVAC mode and target temperature.
  - **Switch**: Restores power state.
  - **Binary Sensor**: Restores state for dry contacts, auxiliary channels, and motion sensors.
  - **Sensor**: Restores numeric values for energy meters (`total-energy`), power sensors, temperature probes, and illuminance sensors, protecting Home Assistant Energy Dashboard metrics across restarts.

---

### Test Coverage & Verification

- **New Unit Tests**:
  - `tests/test_component_light.py`:
    - `test_dali_tunable_white_reboot_state_restoration`: Verifies full state restoration (color mode, kelvin, brightness, power) and confirms brightness event does not downgrade mode.
    - `test_dali_tunable_white_preserves_is_on_and_brightness_on_dim14_event`: Verifies dimension 14 frames preserve `is_on` and `brightness`.
    - `test_dali_rgb_preserves_is_on_and_brightness_on_dim12_event`: Verifies dimension 12 frames preserve `is_on` and `brightness`.
  - `tests/test_state_restoration.py`:
    - `test_switch_state_restoration_on_and_off`: Verifies switch state restoration.
    - `test_climate_state_restoration`: Verifies HVAC mode and target temperature restoration.
    - `test_binary_sensor_state_restoration`: Verifies dry contact, aux, and motion sensor restoration.
    - `test_sensors_state_restoration`: Verifies energy, power, temperature, and illuminance numeric restoration.
- **Verification Results**:
  - Full test suite: **1,204 / 1,204 passed (100%)**
  - OpenWebNet Golden Corpus: **76 / 76 frames valid (PASS)**
  - Ruff static analysis: **0 violations (Clean)**
  - Protocol syntax verified via `openwebnet-mcp`.

Fixes #273
