### PR TITLE
test(golden): add verified physical DALI DT8 Tunable White and dimming fixtures (#273)

### DIFF
--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -536,6 +536,90 @@
     "_file": "who01_lighting.yaml"
   },
   {
+    "id": "light.dim.reply.color_temp.170",
+    "frame": "*#1*25#4#02*14*170##",
+    "direction": "dimension_response",
+    "who": 1,
+    "what": null,
+    "where": "25",
+    "interface": "02",
+    "dimension": 14,
+    "dimension_values": [
+      "170"
+    ],
+    "source": "community-plant-capture",
+    "mcp_valid": true,
+    "mcp_notes": "Lighting: Color temperature reading 170 mireds (~5882 K) verified on BTicino F461 + DALI DT8",
+    "roundtrip": true,
+    "_file": "who01_lighting.yaml"
+  },
+  {
+    "id": "light.dim.write.color_temp.170",
+    "frame": "*#1*25#4#02*#14*170##",
+    "direction": "dimension_write",
+    "who": 1,
+    "what": null,
+    "where": "25",
+    "interface": "02",
+    "dimension": 14,
+    "dimension_values": [
+      "170"
+    ],
+    "source": "community-plant-capture",
+    "mcp_valid": true,
+    "mcp_notes": "Lighting: Set color temperature to 170 mireds (~5882 K) verified on BTicino F461 + DALI DT8",
+    "roundtrip": true,
+    "builder": {
+      "class": "OWNLightingCommand",
+      "method": "set_color_temperature",
+      "args": [
+        "25#4#02",
+        170
+      ]
+    },
+    "_file": "who01_lighting.yaml"
+  },
+  {
+    "id": "light.dim.reply.level.dali.100",
+    "frame": "*#1*25#4#02*1*200*5##",
+    "direction": "dimension_response",
+    "who": 1,
+    "what": null,
+    "where": "25",
+    "interface": "02",
+    "dimension": 1,
+    "dimension_values": [
+      "200",
+      "5"
+    ],
+    "source": "community-plant-capture",
+    "mcp_valid": true,
+    "mcp_notes": "Lighting: Dimension 1 level reading (100% at speed 5) on private DALI bus 02",
+    "roundtrip": true,
+    "_file": "who01_lighting.yaml"
+  },
+  {
+    "id": "light.cmd.off.bus.25",
+    "frame": "*1*0*25#4#02##",
+    "direction": "command",
+    "who": 1,
+    "what": 0,
+    "where": "25",
+    "interface": "02",
+    "source": "community-plant-capture",
+    "mcp_valid": true,
+    "mcp_notes": "Lighting: Turn OFF at address '25' on private DALI bus 02",
+    "roundtrip": true,
+    "builder": {
+      "class": "OWNLightingCommand",
+      "method": "switch_off",
+      "args": [
+        "25#4#02"
+      ]
+    },
+    "_file": "who01_lighting.yaml"
+  },
+  {
     "id": "cover.cmd.up.ptp.93",
     "frame": "*2*1*93##",
     "direction": "command",

--- a/tests/golden/frames/who01_lighting.yaml
+++ b/tests/golden/frames/who01_lighting.yaml
@@ -339,3 +339,65 @@
   mcp_notes: "[Translation] Lighting: Turn OFF at address '53'"
   roundtrip: true
   is_translation: true
+
+- id: light.dim.reply.color_temp.170
+  frame: "*#1*25#4#02*14*170##"
+  direction: dimension_response
+  who: 1
+  what: null
+  where: "25"
+  interface: "02"
+  dimension: 14
+  dimension_values: ["170"]
+  source: community-plant-capture
+  mcp_valid: true
+  mcp_notes: "Lighting: Color temperature reading 170 mireds (~5882 K) verified on BTicino F461 + DALI DT8"
+  roundtrip: true
+
+- id: light.dim.write.color_temp.170
+  frame: "*#1*25#4#02*#14*170##"
+  direction: dimension_write
+  who: 1
+  what: null
+  where: "25"
+  interface: "02"
+  dimension: 14
+  dimension_values: ["170"]
+  source: community-plant-capture
+  mcp_valid: true
+  mcp_notes: "Lighting: Set color temperature to 170 mireds (~5882 K) verified on BTicino F461 + DALI DT8"
+  roundtrip: true
+  builder:
+    class: OWNLightingCommand
+    method: set_color_temperature
+    args: ["25#4#02", 170]
+
+- id: light.dim.reply.level.dali.100
+  frame: "*#1*25#4#02*1*200*5##"
+  direction: dimension_response
+  who: 1
+  what: null
+  where: "25"
+  interface: "02"
+  dimension: 1
+  dimension_values: ["200", "5"]
+  source: community-plant-capture
+  mcp_valid: true
+  mcp_notes: "Lighting: Dimension 1 level reading (100% at speed 5) on private DALI bus 02"
+  roundtrip: true
+
+- id: light.cmd.off.bus.25
+  frame: "*1*0*25#4#02##"
+  direction: command
+  who: 1
+  what: 0
+  where: "25"
+  interface: "02"
+  source: community-plant-capture
+  mcp_valid: true
+  mcp_notes: "Lighting: Turn OFF at address '25' on private DALI bus 02"
+  roundtrip: true
+  builder:
+    class: OWNLightingCommand
+    method: switch_off
+    args: ["25#4#02"]


### PR DESCRIPTION
## Summary
Adds golden test fixtures and synchronizes `corpus.json` using the authentic physical bus traces captured on a BTicino F461 gateway and DALI DT8 ballast (`25#4#02`) reported and verified in #273.

### Added Golden Fixtures (`tests/golden/frames/who01_lighting.yaml`)
1. **`light.dim.reply.color_temp.170`**: `*#1*25#4#02*14*170##`
   - Dimension 14 color temperature status reading of 170 mireds (~5882 K) on private DALI bus interface 02.
2. **`light.dim.write.color_temp.170`**: `*#1*25#4#02*#14*170##`
   - Dimension 14 color temperature write command with builder parity test for `OWNLightingCommand.set_color_temperature("25#4#02", 170)`.
3. **`light.dim.reply.level.dali.100`**: `*#1*25#4#02*1*200*5##`
   - Dimension 1 level reading (100% at transition speed 5) on private DALI bus interface 02.
4. **`light.cmd.off.bus.25`**: `*1*0*25#4#02##`
   - Turn OFF command at address `25` routed to private DALI bus interface 02 with builder parity test for `OWNLightingCommand.switch_off("25#4#02")`.

### Conformance Verification
- `tools/golden/validate_corpus.py`: All 80 fixtures across 11 files verified against `schema.json` and synchronized into `tests/golden/corpus.json`.
- `tests/test_golden_conformance.py`: 201 / 201 tests passing with 100% roundtrip string parsing and builder parity.