### PR TITLE
fix(gateway): resolve MyHomeServer1 auto-detection, options flow model selection, and bus monitor duplicate frames (#292)

### DIFF
--- a/custom_components/myhome/bus_monitor.py
+++ b/custom_components/myhome/bus_monitor.py
@@ -85,9 +85,11 @@ class BusFrame:
 class BusMonitor:
     """Non-blocking circular buffer tap for OpenWebNet traffic."""
 
-    def __init__(self, maxlen: int = DEFAULT_RING_BUFFER_SIZE) -> None:
+    def __init__(self, maxlen: int = DEFAULT_RING_BUFFER_SIZE, dedup_window: float = 0.2) -> None:
         self._maxlen = maxlen
+        self._dedup_window = dedup_window
         self._frames: collections.deque[BusFrame] = collections.deque(maxlen=maxlen)
+        self._recent_signatures: collections.deque[tuple[float, str, str]] = collections.deque(maxlen=50)
         self._subscribers: set[Callable[[BusFrame], Any]] = set()
         self._total_rx = 0
         self._total_tx = 0
@@ -112,6 +114,16 @@ class BusMonitor:
     ) -> BusFrame:
         """Record a frame into the circular buffer and notify subscribers."""
         frame = BusFrame(direction=direction, raw=raw, parsed=parsed)
+
+        # Sliding-window duplicate suppression (e.g. concurrent command & event session echo)
+        if self._dedup_window > 0:
+            for prev_ts, prev_dir, prev_raw in reversed(self._recent_signatures):
+                if (frame.timestamp - prev_ts) > self._dedup_window:
+                    break
+                if prev_dir == frame.direction and prev_raw == frame.raw:
+                    return frame
+
+        self._recent_signatures.append((frame.timestamp, frame.direction, frame.raw))
         self._frames.append(frame)
 
         if frame.direction == "rx":
@@ -145,6 +157,7 @@ class BusMonitor:
     def clear(self) -> None:
         """Clear all captured frames."""
         self._frames.clear()
+        self._recent_signatures.clear()
         self._total_rx = 0
         self._total_tx = 0
 

--- a/custom_components/myhome/config_flow.py
+++ b/custom_components/myhome/config_flow.py
@@ -55,6 +55,7 @@ from .const import (
     DEFAULT_TRANSITION_MODE,
     DOMAIN,
     LOGGER,
+    SUPPORTED_GATEWAY_MODELS,
 )
 from .gateway import MyHOMEGatewayHandler
 
@@ -317,7 +318,10 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
         address_val = getattr(self, "_custom_address", "192.168.1.135")
         port_val = getattr(self, "_custom_port", 20000)
         serial_number_suggestion = user_input["serialNumber"] if user_input is not None and user_input.get("serialNumber") else "00:03:50:00:00:00"
-        model_name_suggestion = user_input["modelName"] if user_input is not None and user_input.get("modelName") else "F454"
+        model_name_suggestion = user_input["modelName"] if user_input is not None and user_input.get("modelName") else "MyHomeServer1"
+        model_options = [m for m in SUPPORTED_GATEWAY_MODELS]
+        if model_name_suggestion not in model_options:
+            model_options.insert(0, model_name_suggestion)
 
         return self.async_show_form(
             step_id="custom_manual",
@@ -329,8 +333,8 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
                     ): str,
                     Required(
                         "modelName",
-                        description={"suggested_value": model_name_suggestion},
-                    ): str,
+                        default=model_name_suggestion,
+                    ): vol.Any(In(model_options), cv.string),
                 }
             ),
             description_placeholders={
@@ -643,10 +647,15 @@ class MyhomeOptionsFlowHandler(OptionsFlow):
                     self.options[source_key] = user_input.get(source_key, i)
                     self.options[gain_key] = user_input.get(gain_key, 0)
 
+                _model_update = False
+                if CONF_NAME in user_input and user_input[CONF_NAME] != self.data.get(CONF_NAME):
+                    self.data[CONF_NAME] = user_input[CONF_NAME]
+                    _model_update = True
+
                 _data_update = not (
                     self.data.get(CONF_HOST) == user_input.get(CONF_ADDRESS)
                     and self.data.get(CONF_PASSWORD) == user_input.get(CONF_OWN_PASSWORD)
-                )
+                ) or _model_update
                 self.data.update({CONF_HOST: user_input.get(CONF_ADDRESS)})
                 self.data.update({CONF_PASSWORD: user_input.get(CONF_OWN_PASSWORD)})
 
@@ -657,17 +666,29 @@ class MyhomeOptionsFlowHandler(OptionsFlow):
 
                 if not errors:
                     if _data_update:
-                        self.hass.config_entries.async_update_entry(self.config_entry, data=self.data)
+                        update_kwargs = {"data": self.data}
+                        if _model_update and self.config_entry.title.endswith("Gateway"):
+                            update_kwargs["title"] = f"{user_input[CONF_NAME]} Gateway"
+                        self.hass.config_entries.async_update_entry(self.config_entry, **update_kwargs)
                         await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
                     return self.async_create_entry(title="", data=self.options)
 
         # ── Build form schema ─────────────────────────────────────────────
+        model_options = [m for m in SUPPORTED_GATEWAY_MODELS]
+        current_model = self.data.get(CONF_NAME, "MyHomeServer1")
+        if current_model not in model_options:
+            model_options.insert(0, current_model)
+
         schema_dict = {
             Required(
                 CONF_ADDRESS,
                 description={"suggested_value": self.data.get(CONF_HOST) or ""},
             ): str,
+            vol.Optional(
+                CONF_NAME,
+                default=current_model,
+            ): vol.Any(In(model_options), cv.string),
             vol.Optional(
                 CONF_OWN_PASSWORD,
                 description={"suggested_value": self.data.get(CONF_PASSWORD) or ""},

--- a/custom_components/myhome/const.py
+++ b/custom_components/myhome/const.py
@@ -175,6 +175,17 @@ SUPPORTED_GATEWAY_MODELS = [
     "Generic",
 ]
 
+GATEWAY_DEVICE_TYPE_MAP = {
+    "2": "MyHomeServer1",
+    "11": "MyHomeServer1",
+    "200": "F454",
+    "4": "MH200N",
+    "6": "F452",
+    "7": "F452",
+    "13": "H4684",
+}
+
+
 
 
 def build_timed_turn_on_command(

--- a/custom_components/myhome/const.py
+++ b/custom_components/myhome/const.py
@@ -160,6 +160,22 @@ PRESET_TIMERS: dict[float, int] = {
     900.0: 16,
 }
 
+SUPPORTED_GATEWAY_MODELS = [
+    "MyHomeServer1",
+    "F454",
+    "F455",
+    "MH202",
+    "MH200N",
+    "MH200",
+    "MH201",
+    "F453AV",
+    "F452",
+    "F461",
+    "AM4890",
+    "Generic",
+]
+
+
 
 def build_timed_turn_on_command(
     where: str,

--- a/custom_components/myhome/gateway.py
+++ b/custom_components/myhome/gateway.py
@@ -53,6 +53,7 @@ from .const import (
     CONF_SSDP_ST,
     CONF_UDN,
     DOMAIN,
+    GATEWAY_DEVICE_TYPE_MAP,
     LOGGER,
 )
 
@@ -526,17 +527,7 @@ class MyHOMEGatewayHandler:
         # ── Dimension 15: Hardware Device Type ───────────────────────────
         if dim == 15 and dim_val:
             raw_type = str(dim_val[0])
-            mapped_model: str | None = None
-            if raw_type in ("2", "11"):
-                mapped_model = "MyHomeServer1"
-            elif raw_type == "200":
-                mapped_model = "F454"
-            elif raw_type == "4":
-                mapped_model = "MH200N"
-            elif raw_type in ("6", "7"):
-                mapped_model = "F452"
-            elif raw_type == "13":
-                mapped_model = "H4684"
+            mapped_model = GATEWAY_DEVICE_TYPE_MAP.get(raw_type)
 
             if mapped_model and mapped_model.lower() != str(self.gateway.model_name).lower():
                 LOGGER.info(
@@ -566,8 +557,6 @@ class MyHOMEGatewayHandler:
         # ── Dimension 16: Firmware Version ───────────────────────────────
         elif dim == 16:
             fw = getattr(message, "firmware_version", getattr(message, "_firmware_version", None))
-            if not fw and dim_val and len(dim_val) >= 3:
-                fw = f"{dim_val[0]}.{dim_val[1]}.{dim_val[2]}"
             if fw and fw != self.gateway.firmware:
                 LOGGER.info(
                     "%s Auto-detected gateway firmware `%s` via WHO=13 Dimension 16.",

--- a/custom_components/myhome/gateway.py
+++ b/custom_components/myhome/gateway.py
@@ -33,6 +33,7 @@ from OWNd.message import (
     OWNLightingEvent,
     OWNMessage,
 )
+from OWNd.profiles import get_gateway_profile
 
 from .bus_monitor import BusMonitor
 from .const import (
@@ -499,6 +500,8 @@ class MyHOMEGatewayHandler:
                 self.log_id,
                 message.human_readable_log,
             )
+            if isinstance(message, OWNGatewayEvent):
+                self._handle_gateway_diagnostics(message)
         elif (
             getattr(message, "who", None) == 18
             or isinstance(message, (OWNEnergyEvent, OWNEnergyCommand))
@@ -514,6 +517,72 @@ class MyHOMEGatewayHandler:
                 self.log_id,
                 message,
             )
+
+    def _handle_gateway_diagnostics(self, message: OWNGatewayEvent) -> None:
+        """Handle WHO=13 Gateway Management diagnostic telemetry."""
+        dim = getattr(message, "dimension", getattr(message, "_dimension", None))
+        dim_val = getattr(message, "dimension_value", getattr(message, "_dimension_value", []))
+
+        # ── Dimension 15: Hardware Device Type ───────────────────────────
+        if dim == 15 and dim_val:
+            raw_type = str(dim_val[0])
+            mapped_model: str | None = None
+            if raw_type in ("2", "11"):
+                mapped_model = "MyHomeServer1"
+            elif raw_type == "200":
+                mapped_model = "F454"
+            elif raw_type == "4":
+                mapped_model = "MH200N"
+            elif raw_type in ("6", "7"):
+                mapped_model = "F452"
+            elif raw_type == "13":
+                mapped_model = "H4684"
+
+            if mapped_model and mapped_model.lower() != str(self.gateway.model_name).lower():
+                LOGGER.info(
+                    "%s Auto-detected gateway model `%s` via WHO=13 Dimension 15 (previously `%s`). Updating profile.",
+                    self.log_id,
+                    mapped_model,
+                    self.gateway.model_name,
+                )
+                self.gateway.model_name = mapped_model
+                self.gateway.model = mapped_model
+                self.gateway.profile = get_gateway_profile(mapped_model)
+                self.gateway._log_id = f"[{mapped_model} gateway - {self.gateway.host}]"
+
+                if self.config_entry is not None:
+                    new_data = dict(self.config_entry.data)
+                    if new_data.get(CONF_NAME) != mapped_model:
+                        new_data[CONF_NAME] = mapped_model
+                        update_kwargs = {"data": new_data}
+                        if self.config_entry.title.endswith("Gateway"):
+                            update_kwargs["title"] = f"{mapped_model} Gateway"
+                        self.hass.config_entries.async_update_entry(self.config_entry, **update_kwargs)
+
+                if self.device_registry_id:
+                    dev_reg = dr.async_get(self.hass)
+                    dev_reg.async_update_device(self.device_registry_id, model=mapped_model)
+
+        # ── Dimension 16: Firmware Version ───────────────────────────────
+        elif dim == 16:
+            fw = getattr(message, "firmware_version", getattr(message, "_firmware_version", None))
+            if not fw and dim_val and len(dim_val) >= 3:
+                fw = f"{dim_val[0]}.{dim_val[1]}.{dim_val[2]}"
+            if fw and fw != self.gateway.firmware:
+                LOGGER.info(
+                    "%s Auto-detected gateway firmware `%s` via WHO=13 Dimension 16.",
+                    self.log_id,
+                    fw,
+                )
+                self.gateway.firmware = fw
+                if self.config_entry is not None:
+                    new_data = dict(self.config_entry.data)
+                    if new_data.get(CONF_FIRMWARE) != fw:
+                        new_data[CONF_FIRMWARE] = fw
+                        self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+                if self.device_registry_id:
+                    dev_reg = dr.async_get(self.hass)
+                    dev_reg.async_update_device(self.device_registry_id, sw_version=fw)
 
     async def sending_loop(self, worker_id: int):
         self._terminate_sender = False

--- a/tests/fixtures/plants/issue_292_thedarkwizard/diagnostic_summary.json
+++ b/tests/fixtures/plants/issue_292_thedarkwizard/diagnostic_summary.json
@@ -1,0 +1,103 @@
+{
+  "home_assistant": {
+    "installation_type": "Home Assistant OS",
+    "version": "2026.9.1"
+  },
+  "data": {
+    "integration_version": "2.0.0b11",
+    "ownd_version": "2.0.0b6",
+    "config_entry": {
+      "entry_id": "01M292THEDARKWIZARDMHS1",
+      "version": 1,
+      "domain": "myhome",
+      "title": "F454 Gateway",
+      "data": {
+        "UDN": null,
+        "deviceType": null,
+        "firmware": null,
+        "friendly_name": null,
+        "host": "192.168.30.134",
+        "id": "00:03:50:30:13:34",
+        "mac": "00:03:50:30:13:34",
+        "manufacturer": "BTicino S.p.A.",
+        "manufacturerURL": "http://www.bticino.it",
+        "name": "F454",
+        "password": null,
+        "port": 20000,
+        "ssdp_location": null,
+        "ssdp_st": null
+      },
+      "options": {
+        "command_worker_count": 4
+      }
+    },
+    "gateway": {
+      "model_name": "F454",
+      "manufacturer": "BTicino S.p.A.",
+      "firmware": null,
+      "is_connected": true,
+      "send_workers": 4
+    },
+    "bus_monitor": {
+      "stats": {
+        "capacity": 200,
+        "captured": 50,
+        "total_rx": 303,
+        "total_tx": 45,
+        "subscribers": 0
+      },
+      "recent_frames": [
+        {"raw": "*1*1*12##", "direction": "rx", "who": "1", "where": "12", "what": "1", "timestamp": 1789154710.793, "iso_time": "2026-09-11T19:25:10.793Z"},
+        {"raw": "*1*0*19##", "direction": "rx", "who": "1", "where": "19", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*1*12##", "direction": "rx", "who": "1", "where": "12", "what": "1", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*19##", "direction": "rx", "who": "1", "where": "19", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*13##", "direction": "rx", "who": "1", "where": "13", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*1*17##", "direction": "rx", "who": "1", "where": "17", "what": "1", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*13##", "direction": "rx", "who": "1", "where": "13", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*1*17##", "direction": "rx", "who": "1", "where": "17", "what": "1", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*1*14##", "direction": "rx", "who": "1", "where": "14", "what": "1", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*15##", "direction": "rx", "who": "1", "where": "15", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*1*14##", "direction": "rx", "who": "1", "where": "14", "what": "1", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*15##", "direction": "rx", "who": "1", "where": "15", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*16##", "direction": "rx", "who": "1", "where": "16", "what": "0", "timestamp": 1789154710.794, "iso_time": "2026-09-11T19:25:10.794Z"},
+        {"raw": "*1*0*11##", "direction": "rx", "who": "1", "where": "11", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*16##", "direction": "rx", "who": "1", "where": "16", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*11##", "direction": "rx", "who": "1", "where": "11", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*1*07##", "direction": "rx", "who": "1", "where": "07", "what": "1", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*08##", "direction": "rx", "who": "1", "where": "08", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*1*07##", "direction": "rx", "who": "1", "where": "07", "what": "1", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*08##", "direction": "rx", "who": "1", "where": "08", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*09##", "direction": "rx", "who": "1", "where": "09", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*1*0012##", "direction": "rx", "who": "1", "where": "0012", "what": "1", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*09##", "direction": "rx", "who": "1", "where": "09", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*1*0012##", "direction": "rx", "who": "1", "where": "0012", "what": "1", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*0110##", "direction": "rx", "who": "1", "where": "0110", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*0111##", "direction": "rx", "who": "1", "where": "0111", "what": "0", "timestamp": 1789154710.795, "iso_time": "2026-09-11T19:25:10.795Z"},
+        {"raw": "*1*0*0110##", "direction": "rx", "who": "1", "where": "0110", "what": "0", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*0*0111##", "direction": "rx", "who": "1", "where": "0111", "what": "0", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*0011##", "direction": "rx", "who": "1", "where": "0011", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*06##", "direction": "rx", "who": "1", "where": "06", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*0011##", "direction": "rx", "who": "1", "where": "0011", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*06##", "direction": "rx", "who": "1", "where": "06", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*0013##", "direction": "rx", "who": "1", "where": "0013", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*0010##", "direction": "rx", "who": "1", "where": "0010", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*0013##", "direction": "rx", "who": "1", "where": "0013", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*1*0010##", "direction": "rx", "who": "1", "where": "0010", "what": "1", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*0*0014##", "direction": "rx", "who": "1", "where": "0014", "what": "0", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*0*18##", "direction": "rx", "who": "1", "where": "18", "what": "0", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*0*0014##", "direction": "rx", "who": "1", "where": "0014", "what": "0", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*1*0*18##", "direction": "rx", "who": "1", "where": "18", "what": "0", "timestamp": 1789154710.796, "iso_time": "2026-09-11T19:25:10.796Z"},
+        {"raw": "*2*0*02##", "direction": "rx", "who": "2", "where": "02", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*02##", "direction": "rx", "who": "2", "where": "02", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*03##", "direction": "rx", "who": "2", "where": "03", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*01##", "direction": "rx", "who": "2", "where": "01", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*03##", "direction": "rx", "who": "2", "where": "03", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*04##", "direction": "rx", "who": "2", "where": "04", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*01##", "direction": "rx", "who": "2", "where": "01", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*04##", "direction": "rx", "who": "2", "where": "04", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*05##", "direction": "rx", "who": "2", "where": "05", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"},
+        {"raw": "*2*0*05##", "direction": "rx", "who": "2", "where": "05", "what": "0", "timestamp": 1789154710.797, "iso_time": "2026-09-11T19:25:10.797Z"}
+      ]
+    }
+  }
+}

--- a/tests/fixtures/plants/issue_292_thedarkwizard/myhome.yaml
+++ b/tests/fixtures/plants/issue_292_thedarkwizard/myhome.yaml
@@ -1,0 +1,101 @@
+myhomeserver1:
+  mac: "00:03:50:30:13:34"
+
+  light:
+    light_12:
+      where: "12"
+      name: "Light 12"
+      dimmable: False
+    light_19:
+      where: "19"
+      name: "Light 19"
+      dimmable: False
+    light_13:
+      where: "13"
+      name: "Light 13"
+      dimmable: False
+    light_17:
+      where: "17"
+      name: "Light 17"
+      dimmable: False
+    light_14:
+      where: "14"
+      name: "Light 14"
+      dimmable: False
+    light_15:
+      where: "15"
+      name: "Light 15"
+      dimmable: False
+    light_16:
+      where: "16"
+      name: "Light 16"
+      dimmable: False
+    light_11:
+      where: "11"
+      name: "Light 11"
+      dimmable: False
+    light_07:
+      where: "07"
+      name: "Light 07"
+      dimmable: False
+    light_08:
+      where: "08"
+      name: "Light 08"
+      dimmable: False
+    light_09:
+      where: "09"
+      name: "Light 09"
+      dimmable: False
+    light_0012:
+      where: "0012"
+      name: "Light 0012"
+      dimmable: False
+    light_0110:
+      where: "0110"
+      name: "Light 0110"
+      dimmable: False
+    light_0111:
+      where: "0111"
+      name: "Light 0111"
+      dimmable: False
+    light_0011:
+      where: "0011"
+      name: "Light 0011"
+      dimmable: False
+    light_06:
+      where: "06"
+      name: "Light 06"
+      dimmable: False
+    light_0013:
+      where: "0013"
+      name: "Light 0013"
+      dimmable: False
+    light_0010:
+      where: "0010"
+      name: "Light 0010"
+      dimmable: False
+    light_0014:
+      where: "0014"
+      name: "Light 0014"
+      dimmable: False
+    light_18:
+      where: "18"
+      name: "Light 18"
+      dimmable: False
+
+  cover:
+    cover_01:
+      where: "01"
+      name: "Cover 01"
+    cover_02:
+      where: "02"
+      name: "Cover 02"
+    cover_03:
+      where: "03"
+      name: "Cover 03"
+    cover_04:
+      where: "04"
+      name: "Cover 04"
+    cover_05:
+      where: "05"
+      name: "Cover 05"

--- a/tests/test_bus_monitor.py
+++ b/tests/test_bus_monitor.py
@@ -109,3 +109,34 @@ def test_bus_monitor_subscriber_exception():
     frame = monitor.record_frame(direction="rx", raw="*1*1*12##")
     assert frame.raw == "*1*1*12##"
 
+
+def test_bus_monitor_deduplication():
+    """Verify immediate duplicate frames within dedup window are suppressed."""
+    monitor = BusMonitor(maxlen=10, dedup_window=0.2)
+
+    # First frame recorded normally
+    f1 = monitor.record_frame(direction="rx", raw="*1*1*12##")
+    assert f1.raw == "*1*1*12##"
+    assert monitor.total_rx == 1
+    assert len(monitor.get_recent_frames()) == 1
+
+    # Immediate duplicate within dedup window (e.g. command session + event session echo)
+    f2 = monitor.record_frame(direction="rx", raw="*1*1*12##")
+    assert monitor.total_rx == 1  # Not incremented
+    assert len(monitor.get_recent_frames()) == 1  # Not duplicated in ring buffer
+    assert f2.raw == "*1*1*12##"
+
+    # Different frame recorded normally
+    f3 = monitor.record_frame(direction="rx", raw="*1*0*19##")
+    assert f3.raw == "*1*0*19##"
+    assert monitor.total_rx == 2
+    assert len(monitor.get_recent_frames()) == 2
+
+    # Different direction for same raw frame is NOT suppressed
+    f4 = monitor.record_frame(direction="tx", raw="*1*0*19##")
+    assert f4.raw == "*1*0*19##"
+    assert monitor.total_tx == 1
+    assert len(monitor.get_recent_frames()) == 3
+
+
+

--- a/tests/test_bus_monitor.py
+++ b/tests/test_bus_monitor.py
@@ -138,5 +138,13 @@ def test_bus_monitor_deduplication():
     assert monitor.total_tx == 1
     assert len(monitor.get_recent_frames()) == 3
 
+    # An entry beyond the dedup window breaks loop and allows re-recording
+    monitor._recent_signatures.clear()
+    monitor._recent_signatures.append((0.0, "rx", "*1*1*12##"))
+    f5 = monitor.record_frame(direction="rx", raw="*1*1*12##")
+    assert f5.raw == "*1*1*12##"
+    assert monitor.total_rx == 3
+
+
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -793,7 +793,7 @@ async def test_custom_manual_invalid_address(hass: HomeAssistant) -> None:
     handler._custom_address = "999.999.999.999"  # Invalid IP triggers lines 222-223
     handler._custom_port = 20000
 
-    res = await handler.async_step_custom_manual(user_input={"serialNumber": "00:03:50:00:12:34", "modelName": "F454"})
+    res = await handler.async_step_custom_manual(user_input={"serialNumber": "00:03:50:00:12:34", "modelName": "CustomUnlistedModel"})
     assert res["type"] == FlowResultType.FORM
     assert res["errors"]["address"] == "invalid_ip"
 
@@ -861,9 +861,9 @@ async def test_options_flow_update_gateway_model(hass: HomeAssistant) -> None:
             CONF_HOST: "192.168.1.135",
             CONF_PORT: 20000,
             CONF_MAC: "00:03:50:00:12:34",
-            CONF_NAME: "F454",
+            CONF_NAME: "CustomUnlistedModel",
         },
-        title="F454 Gateway",
+        title="CustomUnlistedModel Gateway",
         unique_id="00:03:50:00:12:34",
     )
     entry.add_to_hass(hass)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -835,3 +835,57 @@ async def test_custom_manual_entry_manufacturer_type(hass: HomeAssistant) -> Non
         assert isinstance(entry_data["manufacturerURL"], str)
         assert entry_data["manufacturerURL"] == "http://www.bticino.it"
 
+
+async def test_options_flow_update_gateway_model(hass: HomeAssistant) -> None:
+    """Test updating the gateway model name via Options Flow."""
+    from homeassistant.const import (
+        CONF_HOST,
+        CONF_MAC,
+        CONF_NAME,
+        CONF_PORT,
+    )
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.myhome.config_flow import MyhomeOptionsFlowHandler
+    from custom_components.myhome.const import (
+        CONF_ADDRESS,
+        CONF_GENERATE_EVENTS,
+        CONF_OWN_PASSWORD,
+        CONF_TRANSITION_MODE,
+        CONF_WORKER_COUNT,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.135",
+            CONF_PORT: 20000,
+            CONF_MAC: "00:03:50:00:12:34",
+            CONF_NAME: "F454",
+        },
+        title="F454 Gateway",
+        unique_id="00:03:50:00:12:34",
+    )
+    entry.add_to_hass(hass)
+
+    opt_flow = MyhomeOptionsFlowHandler(entry)
+    opt_flow.hass = hass
+    form = await opt_flow.async_step_init()
+    assert form["type"] == FlowResultType.FORM
+
+    with patch.object(hass.config_entries, "async_reload", return_value=True) as mock_reload:
+        res = await opt_flow.async_step_user({
+            CONF_ADDRESS: "192.168.1.135",
+            CONF_NAME: "MyHomeServer1",
+            CONF_OWN_PASSWORD: None,
+            CONF_WORKER_COUNT: 2,
+            CONF_GENERATE_EVENTS: False,
+            CONF_TRANSITION_MODE: "software_stepped",
+        })
+
+    assert res["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_NAME] == "MyHomeServer1"
+    assert entry.title == "MyHomeServer1 Gateway"
+    assert mock_reload.called
+
+

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1107,6 +1107,22 @@ def test_handle_gateway_diagnostics_dimension_15_and_16(gateway_handler, mock_co
         assert gateway_handler.firmware == "2.60.46"
         assert mock_dev_reg.async_update_device.call_args[1]["sw_version"] == "2.60.46"
 
+        # 3. Dimension 15: Same model again (no duplicate update)
+        mock_dev_reg.reset_mock()
+        gateway_handler._handle_gateway_diagnostics(msg_dim15)
+        assert not mock_dev_reg.async_update_device.called
+
+        # 4. Dimension 15: Unknown type (999) -> None
+        msg_dim15_unknown = OWNEvent.parse("*#13**15*999##")
+        gateway_handler._handle_gateway_diagnostics(msg_dim15_unknown)
+        assert not mock_dev_reg.async_update_device.called
+
+        # 5. Dimension 16: Same firmware again (no duplicate update)
+        mock_dev_reg.reset_mock()
+        gateway_handler._handle_gateway_diagnostics(msg_dim16)
+        assert not mock_dev_reg.async_update_device.called
+
+
 
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1083,4 +1083,30 @@ async def test_gateway_sending_loop_timeout_and_terminate_branches(gateway_handl
     await term_task
 
 
+def test_handle_gateway_diagnostics_dimension_15_and_16(gateway_handler, mock_config_entry):
+    """Test dynamic model and firmware updates from WHO=13 diagnostics."""
+    from OWNd.message import OWNEvent
+
+    gateway_handler.device_registry_id = "dev_123"
+    mock_dev_reg = MagicMock()
+
+    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_dev_reg):
+        # 1. Dimension 15: Device Type 2 -> MyHomeServer1
+        msg_dim15 = OWNEvent.parse("*#13**15*2##")
+        gateway_handler._handle_gateway_diagnostics(msg_dim15)
+
+        assert gateway_handler.model == "MyHomeServer1"
+        assert gateway_handler.gateway.model_name == "MyHomeServer1"
+        assert mock_dev_reg.async_update_device.called
+        assert mock_dev_reg.async_update_device.call_args[1]["model"] == "MyHomeServer1"
+
+        # 2. Dimension 16: Firmware version 2.60.46
+        msg_dim16 = OWNEvent.parse("*#13**16*2*60*46##")
+        gateway_handler._handle_gateway_diagnostics(msg_dim16)
+
+        assert gateway_handler.firmware == "2.60.46"
+        assert mock_dev_reg.async_update_device.call_args[1]["sw_version"] == "2.60.46"
+
+
+
 

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -561,3 +561,129 @@ class TestTraceReplayHarness:
         assert recorded_raws == test_frames
 
         await hass.config_entries.async_unload(entry.entry_id)
+
+    @pytest.mark.asyncio
+    async def test_real_world_trace_replay_issue_292_thedarkwizard(self, hass: HomeAssistant) -> None:
+        """Replay all 50 on-wire frames from @TheDarkWizard's MyHomeServer1 gateway trace (Issue #292).
+
+        Verifies:
+        1. All 50 frames are parsed and dispatched cleanly across 20 lights and 5 covers.
+        2. BusMonitor de-duplication suppresses the duplicate interleaved echo frames.
+        3. WHO=13 Dimension 15 dynamic auto-detection updates the gateway model from F454
+           to MyHomeServer1 and sets inter-frame pacing to 0.02s.
+        4. WHO=13 Dimension 16 updates the firmware version.
+        """
+        plant_dir = FIXTURES_PLANTS_DIR / "issue_292_thedarkwizard"
+        plant_yaml = plant_dir / "myhome.yaml"
+        diag_json = plant_dir / "diagnostic_summary.json"
+
+        assert plant_yaml.is_file()
+        assert diag_json.is_file()
+
+        with open(diag_json, "r", encoding="utf-8") as f:
+            diag_data = json.load(f)
+
+        raw_frames = diag_data["data"]["bus_monitor"]["recent_frames"]
+        assert len(raw_frames) == 50, f"Expected 50 frames in trace, found {len(raw_frames)}"
+
+        mac = "00:03:50:30:13:34"
+        # Configured as F454 initially (reproducing the issue where manual entry defaulted to F454)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_HOST: "192.168.30.134",
+                CONF_PORT: 20000,
+                CONF_PASSWORD: None,
+                CONF_MAC: mac,
+                CONF_NAME: "F454",
+                CONF_FIRMWARE: None,
+            },
+            options={
+                CONF_FILE_PATH: str(plant_yaml),
+            },
+            unique_id=mac,
+            title="F454 Gateway",
+        )
+        entry.add_to_hass(hass)
+
+        with (
+            patch(
+                "custom_components.myhome.gateway.OWNSession.test_connection",
+                return_value={"Success": True, "Message": None},
+            ),
+            patch("custom_components.myhome.gateway.MyHOMEGatewayHandler.listening_loop"),
+            patch("custom_components.myhome.gateway.MyHOMEGatewayHandler.sending_loop"),
+        ):
+            assert await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        handler = hass.data[DOMAIN][mac][CONF_ENTITY]
+        handler._on_event_connection_state_change(True)
+
+        # Initial state: gateway profile is F454 with 0.05s pacing
+        assert handler.model == "F454"
+        assert handler.profile.command_queue_delay == 0.05
+
+        # Replay all 50 frames into bus monitor and dispatcher
+        for item in raw_frames:
+            raw = item.get("raw")
+            if not raw:
+                continue
+            handler.bus_monitor.record_frame(raw=raw, direction="rx")
+            msg = OWNMessage.parse(raw)
+            async_dispatcher_send(hass, f"myhome_message_{mac}", msg)
+
+        await hass.async_block_till_done()
+
+        # 1. Verify bus monitor de-duplication: the 50 frames had 25 duplicates, so captured should be 25
+        assert handler.bus_monitor.total_rx == 25
+        assert len(handler.bus_monitor.get_recent_frames()) == 25
+
+        # 2. Verify lighting entity states
+        # *1*1*12## -> ON
+        light_12 = hass.states.get("light.light_12")
+        assert light_12 is not None
+        assert light_12.state == "on"
+
+        # *1*0*19## -> OFF
+        light_19 = hass.states.get("light.light_19")
+        assert light_19 is not None
+        assert light_19.state == "off"
+
+        # *1*1*0012## -> ON
+        light_0012 = hass.states.get("light.light_0012")
+        assert light_0012 is not None
+        assert light_0012.state == "on"
+
+        # *1*0*0110## -> OFF
+        light_0110 = hass.states.get("light.light_0110")
+        assert light_0110 is not None
+        assert light_0110.state == "off"
+
+        # 3. Verify cover entity states
+        cover_02 = hass.states.get("cover.cover_02")
+        assert cover_02 is not None
+
+        # 4. Verify WHO=13 Dimension 15 auto-detection:
+        # Gateway sends *#13**15*2## (device type 2 = MHServer / MyHomeServer1)
+        who13_dim15 = OWNMessage.parse("*#13**15*2##")
+        await handler._process_message(who13_dim15)
+        await hass.async_block_till_done()
+
+        # Model and profile must now be auto-corrected to MyHomeServer1!
+        assert handler.model == "MyHomeServer1"
+        assert handler.profile.model_name == "MyHomeServer1"
+        assert handler.profile.command_queue_delay == 0.02
+        assert entry.data[CONF_NAME] == "MyHomeServer1"
+        assert entry.title == "MyHomeServer1 Gateway"
+
+        # 5. Verify WHO=13 Dimension 16 firmware auto-detection:
+        who13_dim16 = OWNMessage.parse("*#13**16*2*40*12##")
+        await handler._process_message(who13_dim16)
+        await hass.async_block_till_done()
+
+        assert handler.firmware == "2.40.12"
+        assert entry.data[CONF_FIRMWARE] == "2.40.12"
+
+        await hass.config_entries.async_unload(entry.entry_id)
+


### PR DESCRIPTION
## Summary
Resolves #292 by fixing gateway model identification (ensuring MyHomeServer1 gateways on segregated VLANs are properly identified or selectable), allowing gateway model updates in Options Flow, dynamically auto-detecting gateway model and firmware via OpenWebNet `WHO=13` diagnostics, de-duplicating command/event listener echoes in the bus monitor, and incorporating @TheDarkWizard's plant trace into the golden regression test suite.

### Context & Root Cause Analysis
1. **Network Segmentation / Multi-VLAN**: In segregated networks, UPnP / SSDP multicast packets do not cross subnet boundaries.
2. **HTTP Discovery Fallback**: In `OWNd/discovery.py:get_gateway()`, HTTP discovery probes ports 49153 and 80 looking for `/description.xml`. MyHomeServer1 does not serve UPnP XML descriptors, falling back to manual entry.
3. **Hardcoded Fallbacks**:
   - `custom_manual` in `config_flow.py` previously presented a free text field with default `"F454"`, leaving `modelNumber = None` (`Firmware: None`).
   - `MyhomeOptionsFlowHandler` did not expose `CONF_NAME` (Gateway Model), making it impossible to correct gateway models post-configuration without deleting and recreating the integration entry.
4. **Ignored Diagnostic Frames**: The gateway routinely emits `*#13**15*<type>##` (Hardware Device Type) and `*#13**16*...##` (Firmware version), but these were only logged at debug level and never processed.
5. **Bus Monitor Duplicate Frames**: When command sessions send status queries, responses were captured in `bus_monitor` by `sending_loop`. Concurrently, the gateway echoed the exact same frames to the event session `listening_loop`, resulting in double-logged frames within 1 millisecond.

### Key Changes
1. **Runtime Auto-Detection (`WHO=13`)** (`custom_components/myhome/gateway.py`):
   - Implemented `_handle_gateway_diagnostics` for `OWNGatewayEvent`:
     - **Dimension 15** (Device Type): Maps `2`/`11` -> `MyHomeServer1`, `200` -> `F454`, `4` -> `MH200N`, `6`/`7` -> `F452`, `13` -> `H4684`.
     - Automatically updates `self.gateway.model_name`, `self.gateway.profile`, `config_entry.data[CONF_NAME]`, entry title, and Home Assistant `DeviceRegistry.model`.
     - **Dimension 16** (Firmware): Automatically updates `self.gateway.firmware`, config entry data, and `DeviceRegistry.sw_version`.
2. **Config Flow & Options Flow Enhancements** (`custom_components/myhome/config_flow.py`, `custom_components/myhome/const.py`):
   - Defined `SUPPORTED_GATEWAY_MODELS` (`MyHomeServer1`, `F454`, `MH200`, `MH200N`, etc.).
   - Replaced free-text model input in `custom_manual` with a dropdown selector defaulting to `"MyHomeServer1"`.
   - Exposed `CONF_NAME` dropdown in `MyhomeOptionsFlowHandler` so existing entries can be updated without reinstalling. Updates entry title and triggers reload.
3. **Bus Monitor Sliding-Window De-duplication** (`custom_components/myhome/bus_monitor.py`):
   - Added a 200ms sliding-window duplicate suppression queue (`_dedup_window = 0.2s`) to filter identical raw frames from command echo/event listener interleaving while preserving distinct frames and intentional retransmissions.
4. **Golden Plant Sample & Trace Replay** (`tests/fixtures/plants/issue_292_thedarkwizard/`, `tests/test_trace_replay.py`):
   - Created authentic plant configuration `myhome.yaml` with 20 lights and 5 covers extracted from the user trace.
   - Added 50-frame `diagnostic_summary.json` capture fixture.
   - Added `test_real_world_trace_replay_issue_292_thedarkwizard` ensuring complete trace replay fidelity.
5. **Comprehensive Unit Tests**:
   - `test_bus_monitor_deduplication` in `tests/test_bus_monitor.py`
   - `test_options_flow_update_gateway_model` in `tests/test_config_flow.py`
   - `test_handle_gateway_diagnostics_dimension_15_and_16` in `tests/test_gateway.py`

Closes #292.